### PR TITLE
fix(tablekit-input-button): changed appearance

### DIFF
--- a/packages/input-button/src/__snapshots__/index.test.tsx.snap
+++ b/packages/input-button/src/__snapshots__/index.test.tsx.snap
@@ -43,12 +43,13 @@ exports[`@tablecheck/tablekit-input-button should allow passing of custom classN
 
 .emotion-2:checked+div {
   box-shadow: 0 0 0 1px #5C11A6;
-  border: 1px solid #5C11A6;
-  font-weight: 600;
+  background: #5C11A6;
+  color: white;
 }
 
 .emotion-2:checked:hover+div {
-  background: rgba(121,53,210,0.1);
+  background: #5C11A6;
+  color: white;
 }
 
 .emotion-2:disabled+div,
@@ -84,6 +85,7 @@ exports[`@tablecheck/tablekit-input-button should allow passing of custom classN
   text-align: center;
   -webkit-transition: all 120ms ease-in-out;
   transition: all 120ms ease-in-out;
+  background-color: rgba(255, 255, 255, 0.03);
 }
 
 .emotion-4:not([data-is-clicked="true"]):after {
@@ -104,6 +106,10 @@ exports[`@tablecheck/tablekit-input-button should allow passing of custom classN
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-weight: 600;
 }
 
 .emotion-6::after {
@@ -217,12 +223,13 @@ exports[`@tablecheck/tablekit-input-button should correctly apply styling 1`] = 
 
 .emotion-2:checked+div {
   box-shadow: 0 0 0 1px #5C11A6;
-  border: 1px solid #5C11A6;
-  font-weight: 600;
+  background: #5C11A6;
+  color: white;
 }
 
 .emotion-2:checked:hover+div {
-  background: rgba(121,53,210,0.1);
+  background: #5C11A6;
+  color: white;
 }
 
 .emotion-2:disabled+div,
@@ -258,6 +265,7 @@ exports[`@tablecheck/tablekit-input-button should correctly apply styling 1`] = 
   text-align: center;
   -webkit-transition: all 120ms ease-in-out;
   transition: all 120ms ease-in-out;
+  background-color: rgba(255, 255, 255, 0.03);
 }
 
 .emotion-4:not([data-is-clicked="true"]):after {
@@ -278,6 +286,10 @@ exports[`@tablecheck/tablekit-input-button should correctly apply styling 1`] = 
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  font-weight: 600;
 }
 
 .emotion-6::after {

--- a/packages/input-button/src/styled.ts
+++ b/packages/input-button/src/styled.ts
@@ -4,7 +4,8 @@ import { InputFieldProps, InputSize } from '@tablecheck/tablekit-input';
 import {
   FieldHeight,
   Spacing,
-  BORDER_RADIUS
+  BORDER_RADIUS,
+  FontWeight
 } from '@tablecheck/tablekit-theme';
 import { Typography } from '@tablecheck/tablekit-typography';
 import { variant } from '@tablecheck/tablekit-utils';
@@ -72,6 +73,7 @@ export const ButtonDisplay = styled.div<{
   align-items: center;
   text-align: center;
   ${transition};
+  background-color: rgba(255, 255, 255, 0.03);
 
   &:not(${IS_CLICKED_SELECTOR}):after {
     content: '';
@@ -91,6 +93,8 @@ export const TextWrapper = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  ${Typography.Body1};
+  font-weight: ${FontWeight.SemiBold};
 
   &::after {
     content: attr(data-text);
@@ -118,12 +122,13 @@ export const HiddenInput = styled.input`
 
   &:checked + div {
     box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.primary};
-    border: 1px solid ${({ theme }) => theme.colors.primary};
-    font-weight: 600;
+    background: ${({ theme }) => theme.colors.primary};
+    color: white;
   }
 
   &:checked:hover + div {
-    background: ${({ theme }) => theme.colors.hoverPrimaryBackground};
+    background: ${({ theme }) => theme.colors.primary};
+    color: white;
   }
 
   &:disabled + div,


### PR DESCRIPTION
The checked button has solid background insted of outline
Text for all buttons is bold
Font-size is 16px (Typography.Body1)

completes #30


https://user-images.githubusercontent.com/59263605/130033903-2274c9b4-73df-4c2f-b0c2-8c6002303a1f.mov


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-input-button@1.0.1-canary.32.14ac1f06daeb5dfe9d34a2a4d585b4ab6ab8da53.0
  # or 
  yarn add @tablecheck/tablekit-input-button@1.0.1-canary.32.14ac1f06daeb5dfe9d34a2a4d585b4ab6ab8da53.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
