### PR TITLE
feat(tablekit-modal-dialog): add maxWidth and maxHeight props

### DIFF
--- a/packages/modal-dialog/package.json
+++ b/packages/modal-dialog/package.json
@@ -30,6 +30,13 @@
     "react-dom": ">=16.2.0 <18",
     "react-spring": ">=9.0.0-rc.3 <10"
   },
+  "devDependencies": {
+    "@storybook/react": "6.3.6",
+    "@tablecheck/tablekit-enzyme": "^1.0.0",
+    "@types/raf-schd": "4.0.0",
+    "@types/rc-progress": "^2.4.3",
+    "faker": "5.5.3"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/modal-dialog/src/ModalDialog.stories.tsx
+++ b/packages/modal-dialog/src/ModalDialog.stories.tsx
@@ -1,0 +1,246 @@
+import styled from '@emotion/styled';
+import { Story, Meta } from '@storybook/react';
+import { Button } from '@tablecheck/tablekit-button';
+import { Size } from '@tablecheck/tablekit-theme';
+import { Typography, Link } from '@tablecheck/tablekit-typography';
+import faker from 'faker';
+import { Fragment, useState } from 'react';
+
+import { HeaderAppearance, ModalDialog, BaseModalProps } from './index';
+
+export default {
+  title: 'Components/Modal Dialog',
+  component: ModalDialog,
+  parameters: {
+    layout: 'fullscreen',
+    controls: {
+      exclude: ['data-testid']
+    }
+  },
+  argTypes: {
+    width: {
+      control: { type: 'select' },
+      options: [Size.Small, Size.Regular, Size.Large, Size.XLarge]
+    },
+    height: {
+      control: {
+        type: 'text'
+      }
+    }
+  },
+  args: {
+    children: faker.lorem
+      .paragraphs(4, '-----')
+      .split('-----')
+      .map((p) => (
+        <Fragment key={p}>
+          <h3>{faker.lorem.sentence()}</h3>
+          <p>{p}</p>
+        </Fragment>
+      )),
+    headerContent: 'Simple header (maybe custom JSX component)',
+    footerContent: 'Simple footer (maybe custom JSX component)',
+    hasCloseIcon: true
+  }
+} as Meta;
+
+const InfoWrapper = styled.div`
+  ${Typography.Body1};
+  margin: 20px auto 0;
+  display: flex;
+  flex-direction: column;
+  width: 94% !important;
+  p {
+    padding: 10px 0;
+  }
+  ul {
+    li {
+      margin-bottom: 10px;
+    }
+    span {
+      line-height: 1;
+      margin: 0 2px;
+      padding: 3px 5px;
+      white-space: nowrap;
+      border-radius: 3px;
+      font-size: 13px;
+      border: 1px solid #eeeeee;
+      color: rgba(51, 51, 51, 0.9);
+      background-color: #f8f8f8;
+    }
+  }
+`;
+
+const Wrapper = styled.div`
+  ${Typography.Body1};
+  margin: 0 auto;
+  display: flex;
+  width: 94% !important;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Table = styled.table`
+  margin-top: 0px;
+  margin-bottom: 16px;
+  border-collapse: collapse;
+  color: #767676;
+  font-size: 15px;
+  font-family: 'IBM Plex Sans', sans-serif;
+  color: rgb(51, 51, 51);
+  width: 400px;
+  th {
+    font-weight: bold;
+    text-align: start;
+    border-bottom: 1px solid rgb(232, 232, 232);
+  }
+  td {
+    padding: 4px 16px 4px 0px;
+    line-height: 1.5;
+  }
+`;
+const InfoTemplate = () => (
+  <InfoWrapper>
+    <p>
+      This component displays content in a layer that sits above the rest of the
+      page content. Users will not be able to interact with the page until the
+      dialog is closed.
+    </p>
+    <ul>
+      <li>
+        To create uncontrolled modal - pass element (button) to{' '}
+        <span>trigger</span> prop
+      </li>
+      <li>
+        To create controlled modal - pass <span>onOpenChange</span> and{' '}
+        <span>isOpen</span> state
+      </li>
+    </ul>
+    <p>
+      For custom implementation look into{' '}
+      <Link href="https://radix-ui.com/primitives/docs/components/dialog">
+        @radix-ui/react-dialog
+      </Link>
+    </p>
+    <Table>
+      <thead>
+        <tr>
+          <th>@tablekit component</th>
+          <th>@radix component</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>ModalTrigger</td>
+          <td>Trigger</td>
+        </tr>
+        <tr>
+          <td>ModalRoot</td>
+          <td>Root</td>
+        </tr>
+        <tr>
+          <td>ModalContent</td>
+          <td>Content</td>
+        </tr>
+        <tr>
+          <td>ModalOverlay</td>
+          <td>Overlay</td>
+        </tr>
+        <tr>
+          <td>ModalClosePrimitive</td>
+          <td>Close</td>
+        </tr>
+      </tbody>
+    </Table>
+  </InfoWrapper>
+);
+
+export const Information = InfoTemplate.bind({});
+
+const Template: Story<BaseModalProps> = ({ ...args }) => {
+  const [isOpen, setOpen] = useState(false);
+  return (
+    <Wrapper>
+      <ModalDialog {...args} isOpen={isOpen} onOpenChange={setOpen}>
+        {args.children}
+      </ModalDialog>
+      <Button onClick={() => setOpen((value) => !value)}>Toggle Modal</Button>
+    </Wrapper>
+  );
+};
+
+export const BaseModal = Template.bind({});
+
+export const WithoutGutters = Template.bind({});
+WithoutGutters.args = {
+  shouldHideGutters: true
+};
+
+export const OnlyChildren = Template.bind({});
+OnlyChildren.args = {
+  headerContent: undefined,
+  footerContent: undefined
+};
+
+export const WithoutCloseIcon = Template.bind({});
+WithoutCloseIcon.args = {
+  hasCloseIcon: false
+};
+
+export const WarningHeader = Template.bind({});
+WarningHeader.args = {
+  headerAppearance: HeaderAppearance.Warning
+};
+
+export const DangerHeader = Template.bind({});
+DangerHeader.args = {
+  headerAppearance: HeaderAppearance.Danger
+};
+
+export const SmallSize = Template.bind({});
+SmallSize.args = {
+  width: Size.Small
+};
+
+export const RegularSize = Template.bind({});
+RegularSize.args = {
+  width: Size.Regular
+};
+
+export const LargeSize = Template.bind({});
+LargeSize.args = {
+  width: Size.Large
+};
+
+export const XLargeSize = Template.bind({});
+XLargeSize.args = {
+  width: Size.XLarge
+};
+XLargeSize.storyName = 'XLarge Size';
+
+export const CustomSize = Template.bind({});
+CustomSize.args = {
+  width: 200
+};
+CustomSize.storyName = 'Custom Size (200px)';
+
+export const ResponsiveMaxWidth = Template.bind({});
+ResponsiveMaxWidth.args = {
+  maxWidth: {
+    'min-width: 600px': 400,
+    'min-width: 800px': 700,
+    default: 200
+  }
+};
+ResponsiveMaxWidth.storyName = 'Responsive MaxWidth';
+
+export const ResponsiveMaxHeight = Template.bind({});
+ResponsiveMaxHeight.args = {
+  maxHeight: {
+    'min-width: 600px': '70%',
+    'min-width: 800px': '50%',
+    default: '90%'
+  }
+};
+ResponsiveMaxHeight.storyName = 'Responsive MaxHeight';

--- a/packages/modal-dialog/src/ModalDialog.tsx
+++ b/packages/modal-dialog/src/ModalDialog.tsx
@@ -11,6 +11,8 @@ export const ModalDialog = (props: BaseModalProps): JSX.Element => {
     headerContent,
     height,
     width,
+    maxWidth,
+    maxHeight,
     footerContent,
     headerAppearance,
     hasCloseIcon,
@@ -49,6 +51,8 @@ export const ModalDialog = (props: BaseModalProps): JSX.Element => {
         isOpen={isModalOpen}
         height={height}
         width={width}
+        maxWidth={maxWidth}
+        maxHeight={maxHeight}
         onOpenAutoFocus={onOpenAutoFocus}
         onEscapeKeyDown={onEscapeKeyDown}
         onCloseAutoFocus={onCloseAutoFocus}

--- a/packages/modal-dialog/src/components/AnimatedContent.tsx
+++ b/packages/modal-dialog/src/components/AnimatedContent.tsx
@@ -17,12 +17,16 @@ export const AnimatedContent = (
     | 'onEscapeKeyDown'
     | 'onPointerDownOutside'
     | 'shouldPreventCloseOutside'
+    | 'maxWidth'
+    | 'maxHeight'
   >
 ): JSX.Element => {
   const {
     children,
     height,
     width,
+    maxHeight,
+    maxWidth,
     isChromeless,
     isOpen,
     onEscapeKeyDown,
@@ -54,6 +58,8 @@ export const AnimatedContent = (
               forceMount
               height={height}
               width={width}
+              maxWidth={maxWidth}
+              maxHeight={maxHeight}
               style={{
                 opacity: styles.opacity,
                 top: styles.top

--- a/packages/modal-dialog/src/styled.ts
+++ b/packages/modal-dialog/src/styled.ts
@@ -16,7 +16,8 @@ import { Typography } from '@tablecheck/tablekit-typography';
 import {
   getThemeValue,
   padding,
-  ThemeOnlyProps
+  ThemeOnlyProps,
+  mediaQuery
 } from '@tablecheck/tablekit-utils';
 import { ElementType } from 'react';
 import { animated } from 'react-spring';
@@ -66,7 +67,10 @@ export const ModalContent = animated<ElementType>(styled(RxContent, {
       prop
     ) === -1
 })<
-  Pick<BaseModalProps, 'height' | 'width' | 'isChromeless'> & {
+  Pick<
+    BaseModalProps,
+    'height' | 'width' | 'isChromeless' | 'maxWidth' | 'maxHeight'
+  > & {
     shouldPreventOverflow?: boolean;
   }
 >`
@@ -82,8 +86,16 @@ export const ModalContent = animated<ElementType>(styled(RxContent, {
   top: calc(${Spacing.L6} / 2);
   left: 50%;
   transform: translateX(-50%);
-  max-width: calc(100% - ${Spacing.L6});
-  max-height: calc(100% - ${Spacing.L5});
+  ${mediaQuery('maxWidth', (currentSize = `calc(100% - ${Spacing.L6})`) =>
+    typeof currentSize === 'string'
+      ? `max-width: ${currentSize};`
+      : `max-width: ${currentSize}px;`
+  )}
+  ${mediaQuery('maxHeight', (currentSize = `calc(100% - ${Spacing.L5})`) =>
+    typeof currentSize === 'string'
+      ? `max-height: ${currentSize};`
+      : `max-height: ${currentSize}px;`
+  )}
   height: ${({ height }) =>
     typeof height === 'number' ? `${height}px` : height || 'auto'};
   width: ${({ width }) => {

--- a/packages/modal-dialog/src/types.ts
+++ b/packages/modal-dialog/src/types.ts
@@ -1,4 +1,5 @@
 import { Size } from '@tablecheck/tablekit-theme';
+import { MediaQuery } from '@tablecheck/tablekit-utils';
 import { ReactChild } from 'react';
 
 export type AllowedModalWidth =
@@ -40,6 +41,8 @@ export type BaseModalProps = ControlledModalProps & {
   shouldHideGutters?: boolean;
   shouldPreventCloseOutside?: boolean;
   width?: number | string | AllowedModalWidth;
+  maxWidth?: MediaQuery<string | number>;
+  maxHeight?: MediaQuery<string | number>;
 };
 
 export interface ModalBodyProps {


### PR DESCRIPTION
completes #31
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-input-button@1.0.2-canary.33.b6e8bc0d7e1ee8f160d12db9443d05a9ca0e88cf.0
  npm install @tablecheck/tablekit-modal-dialog@1.0.1-canary.33.b6e8bc0d7e1ee8f160d12db9443d05a9ca0e88cf.0
  # or 
  yarn add @tablecheck/tablekit-input-button@1.0.2-canary.33.b6e8bc0d7e1ee8f160d12db9443d05a9ca0e88cf.0
  yarn add @tablecheck/tablekit-modal-dialog@1.0.1-canary.33.b6e8bc0d7e1ee8f160d12db9443d05a9ca0e88cf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
