### PR TITLE
feat: add large size to checkbox and radio inputs

### DIFF
--- a/packages/checkbox/src/Checkbox.stories.tsx
+++ b/packages/checkbox/src/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
 import { Story, Meta } from '@storybook/react';
-import { DARK_COLORS, CLASSIC_COLORS } from '@tablecheck/tablekit-theme';
+import { DARK_COLORS, CLASSIC_COLORS, Size } from '@tablecheck/tablekit-theme';
 import { useState } from 'react';
 import { useDarkMode } from 'storybook-dark-mode';
 
@@ -55,6 +55,12 @@ const Template: Story<CheckboxProps> = ({ children, ...args }) => {
 export const Default = Template.bind({});
 Default.args = {
   children: 'Default'
+};
+
+export const LargeSize = Template.bind({});
+LargeSize.args = {
+  size: Size.Large,
+  children: 'Large Size'
 };
 
 export const Required = Template.bind({});

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -5,7 +5,8 @@ import {
   CheckboxInput,
   InputDisplay,
   CheckboxLabel,
-  RequiredIndicator
+  RequiredIndicator,
+  CheckboxText
 } from './styled';
 import { CheckboxProps } from './types';
 
@@ -39,6 +40,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       onChange,
       value,
       children,
+      size,
       ...inputProps
     } = props;
 
@@ -74,7 +76,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           checked={isChecked}
           type="checkbox"
         />
-        <InputDisplay isInvalid={isInvalid}>
+        <InputDisplay isInvalid={isInvalid} data-size={size}>
           <svg
             width="12px"
             height="12px"
@@ -85,9 +87,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             <polyline className="checkbox-checkmark" points="1 3 4 6 9 1" />
           </svg>
         </InputDisplay>
-        <p>{children}</p>
+        <CheckboxText data-size={size}>{children}</CheckboxText>
         {isRequired ? (
-          <RequiredIndicator role="presentation">*</RequiredIndicator>
+          <RequiredIndicator role="presentation" data-size={size}>
+            *
+          </RequiredIndicator>
         ) : null}
       </CheckboxLabel>
     );

--- a/packages/checkbox/src/styled.ts
+++ b/packages/checkbox/src/styled.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { Spacing, FieldHeight } from '@tablecheck/tablekit-theme';
+import { Spacing, FieldHeight, Size } from '@tablecheck/tablekit-theme';
 import { Typography } from '@tablecheck/tablekit-typography';
 import { getThemeValue } from '@tablecheck/tablekit-utils';
 import type { ThemeOnlyProps } from '@tablecheck/tablekit-utils';
@@ -11,6 +11,7 @@ import {
   IS_CLICKED_SELECTOR
 } from './constants';
 import { checkboxClassicTheme, checkboxThemeNamespace } from './themes';
+import { CheckboxProps } from './types';
 
 export const Text = styled.span`
   display: inline-flex;
@@ -27,8 +28,17 @@ export const RequiredIndicator = styled.span`
   font-weight: bold;
 `;
 
+export const CheckboxText = styled.p<{
+  'data-size'?: CheckboxProps['size'];
+}>`
+  &[data-size='${Size.Large}'] {
+    ${Typography.Body1};
+  }
+`;
+
 export const InputDisplay = styled.span<{
   isInvalid?: boolean;
+  'data-size'?: CheckboxProps['size'];
 }>`
   background: ${getThemeValue(
     `${checkboxThemeNamespace}.backgroundColorBox`,
@@ -49,6 +59,10 @@ export const InputDisplay = styled.span<{
   vertical-align: text-bottom;
   height: 20px;
   width: 20px;
+  &[data-size='${Size.Large}'] {
+    width: 24px;
+    height: 24px;
+  }
 
   svg {
     position: absolute;

--- a/packages/checkbox/src/types.ts
+++ b/packages/checkbox/src/types.ts
@@ -1,3 +1,4 @@
+import { Size } from '@tablecheck/tablekit-theme';
 import { ReactNode, HTMLAttributes } from 'react';
 
 export type Value = string | number | readonly string[] | undefined;
@@ -27,4 +28,6 @@ export type CheckboxProps = HTMLAttributes<HTMLInputElement> &
 
     /** Field value */
     value: Value;
+
+    size?: Size.Regular | Size.Large;
   }>;

--- a/packages/radio/src/Radio.stories.tsx
+++ b/packages/radio/src/Radio.stories.tsx
@@ -1,4 +1,5 @@
 import { Story, Meta } from '@storybook/react';
+import { Size } from '@tablecheck/tablekit-theme';
 import { useState } from 'react';
 
 import { RadioProps } from './types';
@@ -34,6 +35,12 @@ export const Default = DefaultTemplate.bind({});
 const Template: Story<RadioProps> = ({ ...args }) => (
   <Radio {...args}>{args.children}</Radio>
 );
+
+export const LargeSize = Template.bind({});
+LargeSize.args = {
+  size: Size.Large,
+  children: 'Large Size'
+};
 
 export const Required = Template.bind({});
 Required.args = {

--- a/packages/radio/src/Radio.tsx
+++ b/packages/radio/src/Radio.tsx
@@ -37,6 +37,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
       onChange,
       value,
       children,
+      size,
       ...inputProps
     } = props;
 
@@ -74,8 +75,8 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
           value={value}
           ref={ref}
         />
-        <RadioInputDisplay />
-        <RadioText>{children}</RadioText>
+        <RadioInputDisplay data-size={size} />
+        <RadioText data-size={size}>{children}</RadioText>
       </RadioLabel>
     );
   }

--- a/packages/radio/src/styled.ts
+++ b/packages/radio/src/styled.ts
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
-import { Spacing, FieldHeight } from '@tablecheck/tablekit-theme';
+import { Spacing, FieldHeight, Size } from '@tablecheck/tablekit-theme';
 import { Typography } from '@tablecheck/tablekit-typography';
 import { getThemeValue } from '@tablecheck/tablekit-utils';
 
 import { radioClassicTheme, radioThemeNamespace } from './themes';
+import { RadioProps } from './types';
 
 export const IS_CLICKED_ATTR = 'isClicked';
 const IS_CLICKED_SELECTOR = '[data-is-clicked="true"]';
@@ -13,12 +14,22 @@ const TRANSITION_SETTINGS = `${TRANSITION_SPEED} ease-in-out`;
 
 export const RadioText = styled.span`
   ${Typography.Body2};
+  &[data-size='${Size.Large}'] {
+    ${Typography.Body1};
+  }
 `;
 
-export const RadioInputDisplay = styled.span`
+export const RadioInputDisplay = styled.span<{
+  'data-size'?: RadioProps['size'];
+}>`
   position: relative;
-  width: ${Spacing.L4};
-  height: ${Spacing.L4};
+
+  width: 16px;
+  height: 16px;
+  &[data-size='${Size.Large}'] {
+    width: 24px;
+    height: 24px;
+  }
   background: ${getThemeValue(
     `${radioThemeNamespace}.default.backgroundColor`,
     radioClassicTheme.default.backgroundColor
@@ -57,12 +68,16 @@ export const RadioInputDisplay = styled.span`
     position: absolute;
     top: -1px; // Offset for border
     left: -1px;
-    width: ${Spacing.L4};
-    height: ${Spacing.L4};
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     background: ${({ theme }) => theme.colors.primary2};
     transform: scale(0);
     transition: transform ${TRANSITION_SETTINGS};
+  }
+  &[data-size='${Size.Large}']::after {
+    width: 24px;
+    height: 24px;
   }
 `;
 

--- a/packages/radio/src/types.ts
+++ b/packages/radio/src/types.ts
@@ -1,3 +1,4 @@
+import { Size } from '@tablecheck/tablekit-theme';
 import { ReactNode, HTMLAttributes } from 'react';
 
 export type Value = string | number | readonly string[] | undefined;
@@ -22,4 +23,6 @@ export type RadioProps = HTMLAttributes<HTMLInputElement> & {
 
   /** Field value */
   value: Value;
+
+  size?: Size.Regular | Size.Large;
 };


### PR DESCRIPTION
Referencing SUR-561 for designs in use with survey
![CleanShot 2021-10-06 at 15 35 53](https://user-images.githubusercontent.com/1085899/136152822-9dc0cfba-616d-44fa-bcdf-b6b10167256f.png)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-checkbox@1.1.0-canary.57.3bcd94bc8e3f0459831816f9930933b32ca97746.0
  npm install @tablecheck/tablekit-radio@1.1.0-canary.57.3bcd94bc8e3f0459831816f9930933b32ca97746.0
  # or 
  yarn add @tablecheck/tablekit-checkbox@1.1.0-canary.57.3bcd94bc8e3f0459831816f9930933b32ca97746.0
  yarn add @tablecheck/tablekit-radio@1.1.0-canary.57.3bcd94bc8e3f0459831816f9930933b32ca97746.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
