### PR TITLE
release: canary panel & language selector

### DIFF
--- a/packages/language-selector/package.json
+++ b/packages/language-selector/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/tablecheck/tablekit/issues"
   },
-  "version": "1.0.3",
+  "version": "1.0.4-alpha.6+063575e",
   "main": "lib/es5/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
@@ -20,7 +20,7 @@
     "@tablecheck/tablekit-inline-dialog": "^1.0.2",
     "@tablecheck/tablekit-item": "^1.0.2",
     "@tablecheck/tablekit-package-namespace": "^1.0.0",
-    "@tablecheck/tablekit-panel": "^1.0.3",
+    "@tablecheck/tablekit-panel": "^1.0.4-alpha.6+063575e",
     "@tablecheck/tablekit-theme": "^1.0.1",
     "@tablecheck/tablekit-typography": "^1.0.1",
     "@tablecheck/tablekit-utils": "^1.0.0"
@@ -43,5 +43,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "d288d66162c89470081c3c17b12dbae1fa63c13c"
+  "gitHead": "063575ea4685fab048b7b3e14a7b22152dfe437e"
 }

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/tablecheck/tablekit/issues"
   },
-  "version": "1.0.3",
+  "version": "1.0.4-alpha.6+063575e",
   "main": "lib/es5/index.js",
   "module": "lib/esm/index.js",
   "types": "lib/esm/index.d.ts",
@@ -38,5 +38,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "d288d66162c89470081c3c17b12dbae1fa63c13c"
+  "gitHead": "063575ea4685fab048b7b3e14a7b22152dfe437e"
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-language-selector@1.0.5-canary.61.1405202675.0
  npm install @tablecheck/tablekit-panel@1.0.5-canary.61.1405202675.0
  # or 
  yarn add @tablecheck/tablekit-language-selector@1.0.5-canary.61.1405202675.0
  yarn add @tablecheck/tablekit-panel@1.0.5-canary.61.1405202675.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
