### PR TITLE
fix: theme colors

### DIFF
--- a/packages/button/src/styled/themeDefinitions/outlineVariant.ts
+++ b/packages/button/src/styled/themeDefinitions/outlineVariant.ts
@@ -6,8 +6,8 @@ import { resolveColor, VariantProps } from './shared';
 export const outlineVariant = (props: VariantProps): SerializedStyles => css`
   &,
   &:focus {
-    color: ${resolveColor('main', props)};
-    border-color: ${resolveColor('main', props)};
+    color: ${resolveColor('secondary', props)};
+    border-color: ${resolveColor('secondary', props)};
     background: transparent;
   }
 

--- a/packages/button/src/styled/themeDefinitions/subtleVariant.ts
+++ b/packages/button/src/styled/themeDefinitions/subtleVariant.ts
@@ -5,7 +5,7 @@ import { resolveColor, VariantProps } from './shared';
 export const subtleVariant = (props: VariantProps): SerializedStyles => css`
   &,
   &:focus {
-    color: ${resolveColor('main', props)};
+    color: ${resolveColor('secondary', props)};
     background: none;
     border-color: transparent;
   }

--- a/packages/button/src/themes.ts
+++ b/packages/button/src/themes.ts
@@ -10,7 +10,8 @@ import { Color } from './types';
 
 export interface ColorTheme {
   main: PackageThemeValue;
-  text: PackageThemeValue;
+  secondary?: PackageThemeValue;
+  text?: PackageThemeValue;
   active?: PackageThemeValue;
   activeTransparent?: PackageThemeValue;
   hover?: PackageThemeValue;
@@ -34,6 +35,7 @@ declare module '@emotion/react' {
 export const buttonClassicTheme: PackageTheme = {
   [Color.Primary]: {
     main: ({ theme }: ThemeOnlyProps) => theme.colors.primary,
+    secondary: ({ theme }: ThemeOnlyProps) => theme.colors.primary,
     hover: ({ theme }: ThemeOnlyProps) => theme.colors.primaryHover,
     text: ({ theme }: ThemeOnlyProps) => theme.colors.invertedText,
     active: ({ theme }: ThemeOnlyProps) => theme.colors.primary,
@@ -81,6 +83,7 @@ export const buttonDarkTheme: PackageTheme = {
   ...buttonClassicTheme,
   [Color.Primary]: {
     ...buttonClassicTheme[Color.Primary],
+    secondary: ({ theme }: ThemeOnlyProps) => theme.colors.primary2,
     text: 'white'
   },
   [Color.Ghost]: {


### PR DESCRIPTION
The `outline` and `subtle` button appearances need to use a color different than the `main` one in dark mode.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-alert@3.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-banner@2.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-button-group@2.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-button@2.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-calendar@3.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-input-button@2.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-language-selector@2.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-modal-dialog@3.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-panel@2.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-password-field@2.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-phone-input@3.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-select@2.0.2-canary.70.1507385912.0
  npm install @tablecheck/tablekit-topnav@2.0.2-canary.70.1507385912.0
  # or 
  yarn add @tablecheck/tablekit-alert@3.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-banner@2.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-button-group@2.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-button@2.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-calendar@3.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-input-button@2.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-language-selector@2.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-modal-dialog@3.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-panel@2.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-password-field@2.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-phone-input@3.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-select@2.0.2-canary.70.1507385912.0
  yarn add @tablecheck/tablekit-topnav@2.0.2-canary.70.1507385912.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
