### PR TITLE
fix(tablekit-input): use primary2 color for icon

### DIFF
--- a/packages/input/src/themes.ts
+++ b/packages/input/src/themes.ts
@@ -50,7 +50,7 @@ export const inputClassicTheme: PackageTheme = {
       borderColor: ({ theme }: ThemeOnlyProps) => theme.colors.border,
       textColor: ({ theme }: ThemeOnlyProps) => theme.colors.text,
       placeholderColor: ({ theme }: ThemeOnlyProps) => theme.colors.textSubtle,
-      iconColor: ({ theme }: ThemeOnlyProps) => theme.colors.primary
+      iconColor: ({ theme }: ThemeOnlyProps) => theme.colors.primary2
     },
     disabled: {
       borderColor: ({ theme }: ThemeOnlyProps) => theme.colors.border,


### PR DESCRIPTION
Completes 66
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-calendar@3.0.4-canary.72.1528177131.0
  npm install @tablecheck/tablekit-input-button@2.0.4-canary.72.1528177131.0
  npm install @tablecheck/tablekit-input@2.0.3-canary.72.1528177131.0
  npm install @tablecheck/tablekit-password-field@2.0.4-canary.72.1528177131.0
  npm install @tablecheck/tablekit-phone-input@3.0.4-canary.72.1528177131.0
  npm install @tablecheck/tablekit-radio@2.0.3-canary.72.1528177131.0
  npm install @tablecheck/tablekit-select@2.0.4-canary.72.1528177131.0
  npm install @tablecheck/tablekit-textarea@2.0.3-canary.72.1528177131.0
  # or 
  yarn add @tablecheck/tablekit-calendar@3.0.4-canary.72.1528177131.0
  yarn add @tablecheck/tablekit-input-button@2.0.4-canary.72.1528177131.0
  yarn add @tablecheck/tablekit-input@2.0.3-canary.72.1528177131.0
  yarn add @tablecheck/tablekit-password-field@2.0.4-canary.72.1528177131.0
  yarn add @tablecheck/tablekit-phone-input@3.0.4-canary.72.1528177131.0
  yarn add @tablecheck/tablekit-radio@2.0.3-canary.72.1528177131.0
  yarn add @tablecheck/tablekit-select@2.0.4-canary.72.1528177131.0
  yarn add @tablecheck/tablekit-textarea@2.0.3-canary.72.1528177131.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
