### PR TITLE
fix(tablekit-calendar): add selectedTextColor to theme

### DIFF
--- a/packages/calendar/src/Weeks/styled.ts
+++ b/packages/calendar/src/Weeks/styled.ts
@@ -2,7 +2,9 @@ import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { FontWeight, Spacing } from '@tablecheck/tablekit-theme';
 import { Typography } from '@tablecheck/tablekit-typography';
-import { hexToRgba } from '@tablecheck/tablekit-utils';
+import { getThemeValue, hexToRgba } from '@tablecheck/tablekit-utils';
+
+import { calendarClassicTheme, calendarThemeNamespace } from '../themes';
 
 import { DayOfWeek, DayState } from './types';
 
@@ -127,11 +129,17 @@ export const DateButton = styled.button<{
     &:hover > span,
     &:active > span,
     & > span {
-      color: white;
+      color: ${getThemeValue(
+        `${calendarThemeNamespace}.selectedTextColor`,
+        calendarClassicTheme.selectedTextColor
+      )};
     }
     &:hover > span,
     &:active > span {
-      color: white;
+      color: ${getThemeValue(
+        `${calendarThemeNamespace}.selectedTextColor`,
+        calendarClassicTheme.selectedTextColor
+      )};
       background-color: ${({ theme }) => theme.colors.primary2};
     }
     &[data-today='true'] > span:after {

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -3,3 +3,4 @@ export * from './Weeks/types';
 export * from './types';
 export * from './Root';
 export * from './Months';
+export * from './themes';

--- a/packages/calendar/src/themes.ts
+++ b/packages/calendar/src/themes.ts
@@ -1,0 +1,20 @@
+import { PackageNamespace } from '@tablecheck/tablekit-package-namespace';
+import type { PackageThemeValue } from '@tablecheck/tablekit-utils';
+
+export const calendarThemeNamespace = PackageNamespace.Calendar;
+
+interface PackageTheme {
+  selectedTextColor: PackageThemeValue;
+}
+
+declare module '@emotion/react' {
+  export interface Theme {
+    [calendarThemeNamespace]: PackageTheme;
+  }
+}
+
+export const calendarClassicTheme: PackageTheme = {
+  selectedTextColor: 'white'
+};
+
+export const calendarDarkTheme: PackageTheme = calendarClassicTheme;


### PR DESCRIPTION
Completes BEXS-139
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-calendar@3.0.5-canary.74.1577053492.0
  # or 
  yarn add @tablecheck/tablekit-calendar@3.0.5-canary.74.1577053492.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
