### PR TITLE
fix(tablekit-calendar): add selectedTextColor to theme

### DIFF
--- a/packages/calendar/src/Weeks/styled.ts
+++ b/packages/calendar/src/Weeks/styled.ts
@@ -143,7 +143,10 @@ export const DateButton = styled.button<{
       background-color: ${({ theme }) => theme.colors.primary2};
     }
     &[data-today='true'] > span:after {
-      background-color: white;
+      background-color: ${getThemeValue(
+        `${calendarThemeNamespace}.selectedTextColor`,
+        calendarClassicTheme.selectedTextColor
+      )};
     }
   }
 


### PR DESCRIPTION
Completes BEXS-139
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-calendar@3.0.6-canary.75.1581207829.0
  # or 
  yarn add @tablecheck/tablekit-calendar@3.0.6-canary.75.1581207829.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
