### PR TITLE
fix(tablekit-password-field): wrong invalid appearance

### DIFF
--- a/packages/password-field/src/PasswordFieldStateless.tsx
+++ b/packages/password-field/src/PasswordFieldStateless.tsx
@@ -77,7 +77,7 @@ export const PasswordFieldStateless = forwardRef<
             {...inputProps}
             label={label}
             appearance={
-              isTouched && (!!i18nMessages.isInvalidFormat || hasInvalidScore)
+              isTouched && (!!invalidKey || hasInvalidScore)
                 ? Appearance.Invalid
                 : appearance
             }

--- a/packages/password-field/src/utils.ts
+++ b/packages/password-field/src/utils.ts
@@ -7,7 +7,7 @@ export const validationFunc = (value: string): void | I18nMessageFlag => {
   if (!value) {
     return I18nMessageFlag.Required;
   }
-  if (!/(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*\W)/i.test(value)) {
+  if (!/(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\W_])/i.test(value)) {
     return I18nMessageFlag.InvalidFormat;
   }
   return undefined;


### PR DESCRIPTION
Completes BEXS-227 and https://github.com/tablecheck/tablekit/issues/78

<img width="312" alt="Screen Shot 2022-01-06 at 14 09 36" src="https://user-images.githubusercontent.com/1721288/148331601-c89388fc-1cdf-46b8-ad0e-8dcc74f81dbe.png">

<img width="274" alt="Screen Shot 2022-01-06 at 15 20 51" src="https://user-images.githubusercontent.com/1721288/148337989-3c0cc972-2e62-4b99-8698-33e125313083.png">



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-password-field@2.0.5-canary.77.1661826138.0
  # or 
  yarn add @tablecheck/tablekit-password-field@2.0.5-canary.77.1661826138.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
