### PR TITLE
security(tablekit-icon): colors.js has embedded denial of service

### DIFF
--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "5.15.3",
-    "@storybook/react": "6.3.7",
+    "@storybook/react": "6.4.10",
     "@tablecheck/tablekit-package-namespace": "^1.0.0",
     "@tablecheck/tablekit-theme": "^2.0.2",
     "@tablecheck/tablekit-utils": "^1.0.0"


### PR DESCRIPTION
The maintainer has intentionally published a DoS in 1.4.1 and higher. It is recommended to lock to 1.4.0 and move to another package.

This pull request makes the following changes:
* locks colors.js to `1.4.0` by upgrading @storybook/react as per the maintainer's reaction.
* https://github.com/storybookjs/storybook/issues/17179

It relates to the following issue #s:
* Fixes #79