### PR TITLE
fix(tablekit-input): change font size to 16px

### DIFF
--- a/packages/input/src/styled/index.ts
+++ b/packages/input/src/styled/index.ts
@@ -50,14 +50,7 @@ export const InputField = styled.input<InputFieldProps>`
 
   &,
   &::placeholder {
-    ${variant({
-      prop: 'fieldSize',
-      default: InputSize.Regular,
-      variants: {
-        [InputSize.Large]: css(Typography.Body1),
-        [InputSize.Regular]: css(Typography.Body2)
-      }
-    })};
+    ${Typography.Body1};
     line-height: initial;
   }
 


### PR DESCRIPTION
Fixes BEXS-244

<img width="1563" alt="Screen Shot 2022-01-27 at 15 32 22" src="https://user-images.githubusercontent.com/1721288/151304575-b7f39fd9-f820-4340-9521-43217f0f389e.png">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-alert@3.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-avatar@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-badge@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-banner@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-button-group@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-button@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-calendar@3.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-checkbox@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-enzyme@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-free-icon-config@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-icon@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-inline-dialog@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-input-button@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-input@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-item@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-language-selector@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-logo@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-modal-dialog@3.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-panel@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-password-field@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-phone-input@3.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-pro-icon-config@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-radio@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-select@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-sidenav@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-spinner@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-table@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-tabs@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-tag@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-textarea@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-theme@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-toggle@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-tooltip@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-topnav@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-typography@2.1.1-canary.85.1754848678.0
  npm install @tablecheck/tablekit-utils@1.1.1-canary.85.1754848678.0
  # or 
  yarn add @tablecheck/tablekit-alert@3.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-avatar@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-badge@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-banner@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-button-group@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-button@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-calendar@3.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-checkbox@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-enzyme@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-free-icon-config@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-icon@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-inline-dialog@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-input-button@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-input@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-item@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-language-selector@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-logo@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-modal-dialog@3.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-panel@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-password-field@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-phone-input@3.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-pro-icon-config@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-radio@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-select@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-sidenav@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-spinner@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-table@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-tabs@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-tag@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-textarea@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-theme@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-toggle@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-tooltip@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-topnav@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-typography@2.1.1-canary.85.1754848678.0
  yarn add @tablecheck/tablekit-utils@1.1.1-canary.85.1754848678.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
