### PR TITLE
WIP: fix: full height panel for mobile devices

### DIFF
--- a/packages/language-selector/package.json
+++ b/packages/language-selector/package.json
@@ -20,7 +20,7 @@
     "@tablecheck/tablekit-inline-dialog": "^2.1.1",
     "@tablecheck/tablekit-item": "^2.1.1",
     "@tablecheck/tablekit-package-namespace": "^1.1.0",
-    "@tablecheck/tablekit-panel": "^2.1.1",
+    "@tablecheck/tablekit-panel": "2.1.2-canary.90.2028240272.0",
     "@tablecheck/tablekit-theme": "^2.1.1",
     "@tablecheck/tablekit-typography": "^2.1.1",
     "@tablecheck/tablekit-utils": "^1.1.1"

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -18,7 +18,6 @@
     "@tablecheck/tablekit-package-namespace": "^1.1.0",
     "@tablecheck/tablekit-theme": "^2.1.1",
     "@tablecheck/tablekit-utils": "^1.1.1",
-    "body-scroll-lock": "4.0.0-beta.0",
     "re-resizable": "6.9.0"
   },
   "peerDependencies": {

--- a/packages/panel/src/Panel.stories.tsx
+++ b/packages/panel/src/Panel.stories.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { Story, Meta } from '@storybook/react';
 import { Button } from '@tablecheck/tablekit-button';
-import { ItemGroup, ItemGroupOrientation } from '@tablecheck/tablekit-item';
 import { Typography } from '@tablecheck/tablekit-typography';
 import faker from 'faker';
 import { useState } from 'react';
@@ -39,28 +38,27 @@ const Wrapper = styled.div`
   }
 `;
 
-const BodyLockWrapper = styled.div`
-  height: 130vh;
-`;
-
-const StyledPanel = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  button {
-    margin-top: 20px;
-  }
-`;
-
-const StyledScrollable = styled.div`
+const BodyScrollLockWrapper = styled.div`
+  height: 200vh;
   display: flex;
   flex-direction: column;
-  height: 110vh;
-  overflow-y: auto;
-  padding: 15px;
-  p {
-    padding-top: 10px;
+  align-items: center;
+  background: linear-gradient(
+    180deg,
+    rgba(2, 0, 36, 0) 0%,
+    rgba(2, 0, 36, 0) 50%,
+    rgba(222, 0, 255, 1) 100%
+  );
+  width: 90vw;
+`;
+
+const StyledPanel = styled(Panel)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  button {
+    margin-top: 20px;
   }
 `;
 
@@ -81,11 +79,13 @@ const Template: Story<PanelProps> = ({ ...args }) => {
         </ul>
       </div>
       <Button onClick={() => setOpen(true)}>{args.position} panel</Button>
-      <Panel {...args} isOpen={isOpen} onClickOutside={() => setOpen(false)}>
-        <StyledPanel>
-          <Button onClick={() => setOpen(false)}>Close Panel</Button>
-        </StyledPanel>
-      </Panel>
+      <StyledPanel
+        {...args}
+        isOpen={isOpen}
+        onClickOutside={() => setOpen(false)}
+      >
+        <Button onClick={() => setOpen(false)}>Close Panel</Button>
+      </StyledPanel>
     </Wrapper>
   );
 };
@@ -114,7 +114,7 @@ TopPanel.args = {
   height: '100px'
 };
 
-const BodyLockTemplate: Story<PanelProps> = ({ ...args }) => {
+const BodyScrollLockTemplate: Story<PanelProps> = ({ ...args }) => {
   const [state, setState] = useState({
     isOpenRight: false,
     isOpenLeft: false
@@ -132,39 +132,31 @@ const BodyLockTemplate: Story<PanelProps> = ({ ...args }) => {
     });
   };
   return (
-    <BodyLockWrapper>
-      <ItemGroup hasIndent orientation={ItemGroupOrientation.Horizontal}>
-        <Button onClick={toggleLeft}>Toggle Left Panel</Button>
-        <Button onClick={toggleRight}>Toggle Right Panel</Button>
-      </ItemGroup>
+    <BodyScrollLockWrapper>
+      <Button onClick={toggleLeft}>Toggle Left Panel</Button>
+      <p>
+        This story is for testing the case where the panel has full height, and
+        making sure it maintains it properly in physical devices when scrolling
+        changes the height of the viewport
+      </p>
       <Panel {...args} position={PanelPosition.Left} isOpen={state.isOpenLeft}>
-        <StyledPanel>
-          <StyledScrollable>
-            <Button onClick={toggleLeft}>Close Panel</Button>
-            <p>{faker.lorem.paragraph(30)}</p>
-          </StyledScrollable>
-        </StyledPanel>
-      </Panel>
-      {state.isOpenRight && (
+        <Button onClick={toggleLeft}>Close Panel</Button>
+        <Button onClick={toggleRight}>Toggle Right Panel</Button>
+        <p>{faker.lorem.paragraph(30)}</p>
         <Panel
           {...args}
           position={PanelPosition.Right}
           isOpen={state.isOpenRight}
         >
-          <StyledPanel>
-            <StyledScrollable>
-              <Button onClick={toggleRight}>Close Panel</Button>
-              <p>{faker.lorem.paragraph(30)}</p>
-            </StyledScrollable>
-          </StyledPanel>
+          <Button onClick={toggleRight}>Close Panel</Button>
+          <p>{faker.lorem.paragraph(25)}</p>
         </Panel>
-      )}
-    </BodyLockWrapper>
+      </Panel>
+    </BodyScrollLockWrapper>
   );
 };
 
-export const BodyLock = BodyLockTemplate.bind({});
-BodyLock.args = {
-  shouldDisableBodyScroll: true,
-  width: '400px'
+export const BodyScrollLock = BodyScrollLockTemplate.bind({});
+BodyScrollLock.args = {
+  shouldDisableBodyScroll: true
 };

--- a/packages/panel/src/Panel.tsx
+++ b/packages/panel/src/Panel.tsx
@@ -14,8 +14,8 @@ export const Panel = forwardRef<HTMLDivElement, PanelProps>(
       onClickOutside,
       shouldDisableBodyScroll = false,
       position = PanelPosition.Right,
-      width = '100%',
-      height = '100%',
+      width,
+      height,
       ...restProps
     }: PanelProps,
     ref

--- a/packages/panel/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/panel/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -19,7 +19,10 @@ exports[`Panel should allow passing of custom className 1`] = `
   -ms-transform: translateX(0);
   transform: translateX(0);
   width: 100%;
-  height: 100%;
+  min-height: max(100%, 100vh);
+  min-height: -webkit-fill-available;
+  max-height: max(100%, 100vh);
+  overflow-y: auto;
   box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.1);
   background-color: white;
   z-index: 300;
@@ -34,11 +37,9 @@ exports[`Panel should allow passing of custom className 1`] = `
   <StaticPanelContainer
     className="test-class"
     data-ignore="scroll-lock-ignore"
-    height="100%"
     isOpen={true}
     onClick={[Function]}
     position="right"
-    width="100%"
   >
     <Noop />
     <div
@@ -69,7 +70,10 @@ exports[`Panel should correctly apply styling 1`] = `
   -ms-transform: translateX(0);
   transform: translateX(0);
   width: 100%;
-  height: 100%;
+  min-height: max(100%, 100vh);
+  min-height: -webkit-fill-available;
+  max-height: max(100%, 100vh);
+  overflow-y: auto;
   box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.1);
   background-color: white;
   z-index: 300;
@@ -82,11 +86,9 @@ exports[`Panel should correctly apply styling 1`] = `
 >
   <StaticPanelContainer
     data-ignore="scroll-lock-ignore"
-    height="100%"
     isOpen={true}
     onClick={[Function]}
     position="right"
-    width="100%"
   >
     <Noop />
     <div

--- a/packages/panel/src/bodyScrollLock.ts
+++ b/packages/panel/src/bodyScrollLock.ts
@@ -1,0 +1,301 @@
+// forked from https://github.com/willmcpo/body-scroll-lock/
+// ----
+// Adopted and modified solution from Bohdan Didukh (2017)
+// https://stackoverflow.com/questions/41594997/ios-10-safari-prevent-scrolling-behind-a-fixed-overlay-and-maintain-scroll-posi
+
+export interface BodyScrollOptions {
+  reserveScrollBarGap?: boolean;
+  allowTouchMove?: (element: HTMLElement | null) => boolean;
+}
+
+interface Lock {
+  targetElement: HTMLElement;
+  options: BodyScrollOptions;
+}
+
+const eventListenerPassiveOption: AddEventListenerOptions = {
+  passive: true
+};
+
+const isIosDevice =
+  typeof window !== 'undefined' &&
+  window.navigator &&
+  window.navigator.platform &&
+  (/iP(ad|hone|od)/.test(window.navigator.platform) ||
+    (window.navigator.platform === 'MacIntel' &&
+      window.navigator.maxTouchPoints > 1));
+type HandleScrollEvent = TouchEvent;
+
+let locks: Array<Lock> = [];
+let isDocumentListenerAdded = false;
+let initialClientY = -1;
+let previousBodyOverflowSetting: string | undefined;
+let previousBodyPosition:
+  | {
+      position: string;
+      top: string;
+      left: string;
+    }
+  | undefined;
+let previousBodyPaddingRight: string | undefined;
+
+// returns true if `el` should be allowed to receive touchmove events.
+const allowTouchMove = (el: HTMLElement | null): boolean =>
+  locks.some((lock) => {
+    if (lock.options.allowTouchMove && lock.options.allowTouchMove(el)) {
+      return true;
+    }
+
+    return false;
+  });
+
+const preventDefault = (rawEvent: HandleScrollEvent): boolean => {
+  const e = rawEvent || window.event;
+
+  // For the case whereby consumers adds a touchmove event listener to document.
+  // Recall that we do document.addEventListener('touchmove', preventDefault, { passive: false })
+  // in disableBodyScroll - so if we provide this opportunity to allowTouchMove, then
+  // the touchmove event on document will break.
+  if (e.target && allowTouchMove(e.target as HTMLElement)) {
+    return true;
+  }
+
+  // Do not prevent if the event has more than one touch (usually meaning this is a multi touch gesture like pinch to zoom).
+  if (e.touches.length > 1) return true;
+
+  if (e.preventDefault) e.preventDefault();
+
+  return false;
+};
+
+const setOverflowHidden = (options?: BodyScrollOptions) => {
+  // If previousBodyPaddingRight is already set, don't set it again.
+  if (previousBodyPaddingRight === undefined) {
+    const shouldReserveScrollBarGap =
+      !!options && options.reserveScrollBarGap === true;
+    const scrollBarGap =
+      window.innerWidth - document.documentElement.clientWidth;
+
+    if (shouldReserveScrollBarGap && scrollBarGap > 0) {
+      const computedBodyPaddingRight = parseInt(
+        window
+          .getComputedStyle(document.body)
+          .getPropertyValue('padding-right'),
+        10
+      );
+      previousBodyPaddingRight = document.body.style.paddingRight;
+      document.body.style.paddingRight = `${
+        computedBodyPaddingRight + scrollBarGap
+      }px`;
+    }
+  }
+
+  // If previousBodyOverflowSetting is already set, don't set it again.
+  if (previousBodyOverflowSetting === undefined) {
+    previousBodyOverflowSetting = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+};
+
+const restoreOverflowSetting = () => {
+  if (previousBodyPaddingRight !== undefined) {
+    document.body.style.paddingRight = previousBodyPaddingRight;
+
+    // Restore previousBodyPaddingRight to undefined so setOverflowHidden knows it
+    // can be set again.
+    previousBodyPaddingRight = undefined;
+  }
+
+  if (previousBodyOverflowSetting !== undefined) {
+    document.body.style.overflow = previousBodyOverflowSetting;
+
+    // Restore previousBodyOverflowSetting to undefined
+    // so setOverflowHidden knows it can be set again.
+    previousBodyOverflowSetting = undefined;
+  }
+};
+
+const setPositionFixed = () =>
+  window.requestAnimationFrame(() => {
+    // If previousBodyPosition is already set, don't set it again.
+    if (previousBodyPosition === undefined) {
+      previousBodyPosition = {
+        position: document.body.style.position,
+        top: document.body.style.top,
+        left: document.body.style.left
+      };
+
+      // Update the dom inside an animation frame
+      const { scrollY, scrollX } = window;
+      document.body.style.position = 'fixed';
+      document.body.style.top = `${-scrollY}px`;
+      document.body.style.left = `${-scrollX}px`;
+    }
+  });
+
+const restorePositionSetting = () => {
+  if (previousBodyPosition !== undefined) {
+    // Convert the position from "px" to Int
+    const y = -parseInt(document.body.style.top, 10);
+    const x = -parseInt(document.body.style.left, 10);
+
+    // Restore styles
+    document.body.style.position = previousBodyPosition.position;
+    document.body.style.top = previousBodyPosition.top;
+    document.body.style.left = previousBodyPosition.left;
+
+    // Restore scroll
+    window.scrollTo(x, y);
+
+    previousBodyPosition = undefined;
+  }
+};
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#Problems_and_solutions
+const isTargetElementTotallyScrolled = (targetElement: HTMLElement): boolean =>
+  targetElement
+    ? targetElement.scrollHeight - targetElement.scrollTop <=
+      targetElement.clientHeight
+    : false;
+
+const handleScroll = (
+  event: HandleScrollEvent,
+  targetElement: HTMLElement
+): boolean => {
+  const clientY = event.targetTouches[0].clientY - initialClientY;
+
+  if (event.target && allowTouchMove(event.target as HTMLElement)) {
+    return false;
+  }
+
+  if (targetElement && targetElement.scrollTop === 0 && clientY > 0) {
+    // element is at the top of its scroll.
+    return preventDefault(event);
+  }
+
+  if (isTargetElementTotallyScrolled(targetElement) && clientY < 0) {
+    // element is at the bottom of its scroll.
+    return preventDefault(event);
+  }
+
+  event.stopPropagation();
+  return true;
+};
+
+export const disableBodyScroll = (
+  targetElement: HTMLElement,
+  options?: BodyScrollOptions
+): void => {
+  // targetElement must be provided
+  if (!targetElement) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'disableBodyScroll unsuccessful - targetElement must be provided when calling disableBodyScroll on IOS devices.'
+    );
+    return;
+  }
+
+  // disableBodyScroll must not have been called on this targetElement before
+  if (locks.some((lock) => lock.targetElement === targetElement)) {
+    return;
+  }
+
+  const lock = {
+    targetElement,
+    options: options || {}
+  };
+
+  locks = [...locks, lock];
+
+  if (isIosDevice) {
+    setPositionFixed();
+  } else {
+    setOverflowHidden(options);
+  }
+
+  if (isIosDevice) {
+    targetElement.ontouchstart = (event: HandleScrollEvent) => {
+      if (event.targetTouches.length === 1) {
+        // detect single touch.
+        initialClientY = event.targetTouches[0].clientY;
+      }
+    };
+    targetElement.ontouchmove = (event: HandleScrollEvent) => {
+      if (event.targetTouches.length === 1) {
+        // detect single touch.
+        handleScroll(event, targetElement);
+      }
+    };
+
+    if (!isDocumentListenerAdded) {
+      document.addEventListener('touchmove', preventDefault, {
+        passive: false
+      });
+      isDocumentListenerAdded = true;
+    }
+  }
+};
+
+export const clearAllBodyScrollLocks = (): void => {
+  if (isIosDevice) {
+    // Clear all locks ontouchstart/ontouchmove handlers, and the references.
+    locks.forEach((lock: Lock) => {
+      lock.targetElement.ontouchstart = null;
+      lock.targetElement.ontouchmove = null;
+    });
+
+    if (isDocumentListenerAdded) {
+      document.removeEventListener(
+        'touchmove',
+        preventDefault,
+        eventListenerPassiveOption
+      );
+      isDocumentListenerAdded = false;
+    }
+
+    // Reset initial clientY.
+    initialClientY = -1;
+  }
+
+  if (isIosDevice) {
+    restorePositionSetting();
+  } else {
+    restoreOverflowSetting();
+  }
+
+  locks = [];
+};
+
+export const enableBodyScroll = (targetElement: HTMLElement): void => {
+  if (!targetElement) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'enableBodyScroll unsuccessful - targetElement must be provided when calling enableBodyScroll on IOS devices.'
+    );
+    return;
+  }
+
+  locks = locks.filter((lock) => lock.targetElement !== targetElement);
+
+  if (isIosDevice) {
+    targetElement.ontouchstart = null;
+    targetElement.ontouchmove = null;
+
+    if (isDocumentListenerAdded && locks.length === 0) {
+      document.removeEventListener(
+        'touchmove',
+        preventDefault,
+        eventListenerPassiveOption
+      );
+      isDocumentListenerAdded = false;
+    }
+  }
+
+  if (locks.length === 0) {
+    if (isIosDevice) {
+      restorePositionSetting();
+    } else {
+      restoreOverflowSetting();
+    }
+  }
+};

--- a/packages/panel/src/styled/StaticPanel.ts
+++ b/packages/panel/src/styled/StaticPanel.ts
@@ -35,7 +35,17 @@ export const StaticContainer = styled('div', {
     }`;
   }};
   ${mediaQuery('width', (value) => `width: ${value || '100%'}`)};
-  ${mediaQuery('height', (value) => `height: ${value || '100%'}`)};
+  ${mediaQuery(
+    'height',
+    (value) =>
+      `${
+        value
+          ? `height: ${value};`
+          : 'min-height: max(100%, 100vh); min-height: -webkit-fill-available;'
+      }`
+  )}
+  max-height: max(100%, 100vh);
+  overflow-y: auto;
   ${DEPTH.FIXED};
   background-color: ${getThemeValue(
     `${panelThemeNamespace}.backgroundColor`,

--- a/packages/panel/src/useBodyScrollLock.tsx
+++ b/packages/panel/src/useBodyScrollLock.tsx
@@ -1,9 +1,10 @@
+import { MutableRefObject, useEffect } from 'react';
+
 import {
   clearAllBodyScrollLocks,
   disableBodyScroll,
   enableBodyScroll
-} from 'body-scroll-lock';
-import { MutableRefObject, useEffect } from 'react';
+} from './bodyScrollLock';
 
 const OBSERVER_CLASS_NAME = 'PanelScrollObserver';
 


### PR DESCRIPTION
when scrolling a full height panel on mobile (physical devices only), panel does not properly fill the entire height of the device (caused by dynamic viewport height because of the browser UI shrinking or expanding)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-language-selector@2.1.2-canary.90.2089325350.0
  npm install @tablecheck/tablekit-panel@2.1.2-canary.90.2089325350.0
  # or 
  yarn add @tablecheck/tablekit-language-selector@2.1.2-canary.90.2089325350.0
  yarn add @tablecheck/tablekit-panel@2.1.2-canary.90.2089325350.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
