### PR TITLE
fix(tablekit-modal-dialog): correctly forward on data-testid prop

### DIFF
--- a/packages/modal-dialog/src/ModalDialog.stories.tsx
+++ b/packages/modal-dialog/src/ModalDialog.stories.tsx
@@ -152,7 +152,11 @@ export const Information = InfoTemplate.bind({});
 
 const Template: Story<BaseModalProps> = ({ isOpen, onOpenChange, ...args }) => (
   <Wrapper>
-    <ModalDialog {...args} trigger={<Button>Toggle Modal</Button>}>
+    <ModalDialog
+      {...args}
+      data-testid="Modal Test Id"
+      trigger={<Button>Toggle Modal</Button>}
+    >
       {args.children}
     </ModalDialog>
   </Wrapper>

--- a/packages/modal-dialog/src/ModalDialog.tsx
+++ b/packages/modal-dialog/src/ModalDialog.tsx
@@ -26,7 +26,8 @@ export const ModalDialog = (props: BaseModalProps): JSX.Element => {
     onPointerDownOutside,
     onOpenAutoFocus,
     onEscapeKeyDown,
-    onCloseAutoFocus
+    onCloseAutoFocus,
+    'data-testid': testId
   } = props;
   // internal state of uncontrolled modal, needed for animation
   const [isOpenInternal, setIsOpenInternal] = useState(false);
@@ -60,6 +61,7 @@ export const ModalDialog = (props: BaseModalProps): JSX.Element => {
         onPointerDownOutside={onPointerDownOutside}
         isChromeless={isChromeless}
         shouldPreventCloseOutside={shouldPreventCloseOutside}
+        data-testid={testId}
       >
         {typeof headerContent !== 'undefined' ? (
           <ModalHeader

--- a/packages/modal-dialog/src/components/AnimatedContent.tsx
+++ b/packages/modal-dialog/src/components/AnimatedContent.tsx
@@ -19,6 +19,7 @@ export const AnimatedContent = (
     | 'shouldPreventCloseOutside'
     | 'maxWidth'
     | 'maxHeight'
+    | 'data-testid'
   >
 ): JSX.Element => {
   const {
@@ -33,7 +34,8 @@ export const AnimatedContent = (
     onOpenAutoFocus,
     onCloseAutoFocus,
     shouldPreventCloseOutside,
-    onPointerDownOutside
+    onPointerDownOutside,
+    'data-testid': testId
   } = props;
   const transition = useTransition(isOpen, {
     from: { opacity: 0, top: Spacing.L6 },
@@ -76,6 +78,7 @@ export const AnimatedContent = (
                   e.preventDefault();
                 }
               }}
+              data-testid={testId}
             >
               {children}
             </ModalContent>

--- a/packages/modal-dialog/src/types.ts
+++ b/packages/modal-dialog/src/types.ts
@@ -25,6 +25,7 @@ type ControlledModalProps =
     };
 
 export type BaseModalProps = ControlledModalProps & {
+  ['data-testid']?: string;
   children: ReactChild | null | (ReactChild | null)[];
   footerContent?: JSX.Element | string;
   hasCloseIcon?: boolean;


### PR DESCRIPTION
Forward on the data-testid prop so we can target a dialog correctly when there are multiple displayed.

![CleanShot 2022-03-30 at 10 54 37](https://user-images.githubusercontent.com/1085899/160736422-c168817c-6238-41d4-bf15-6a79c9047f40.png)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-modal-dialog@3.1.2-canary.91.2062204281.0
  # or 
  yarn add @tablecheck/tablekit-modal-dialog@3.1.2-canary.91.2062204281.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
