### PR TITLE
fix(tablekit-modal-dialog): passthrough classname to modal content

### DIFF
--- a/packages/modal-dialog/src/ModalDialog.tsx
+++ b/packages/modal-dialog/src/ModalDialog.tsx
@@ -9,6 +9,7 @@ import { BaseModalProps } from './types';
 export const ModalDialog = (props: BaseModalProps): JSX.Element => {
   const {
     children,
+    className,
     headerContent,
     height,
     width,
@@ -50,6 +51,7 @@ export const ModalDialog = (props: BaseModalProps): JSX.Element => {
     <ModalRoot onOpenChange={onOpenChangeHandler} open={isModalOpen}>
       {trigger ? <RxTrigger asChild>{trigger}</RxTrigger> : null}
       <AnimatedContent
+        className={className}
         isOpen={isModalOpen}
         height={height}
         width={width}

--- a/packages/modal-dialog/src/components/AnimatedContent.tsx
+++ b/packages/modal-dialog/src/components/AnimatedContent.tsx
@@ -8,6 +8,7 @@ export const AnimatedContent = (
   props: Pick<
     BaseModalProps,
     | 'children'
+    | 'className'
     | 'height'
     | 'width'
     | 'isChromeless'
@@ -24,6 +25,7 @@ export const AnimatedContent = (
 ): JSX.Element => {
   const {
     children,
+    className,
     height,
     width,
     maxHeight,
@@ -57,6 +59,7 @@ export const AnimatedContent = (
               }}
             />
             <ModalContent
+              className={className}
               forceMount
               height={height}
               width={width}

--- a/packages/modal-dialog/src/styled.ts
+++ b/packages/modal-dialog/src/styled.ts
@@ -71,7 +71,8 @@ export const ModalContent = animated<ElementType>(styled(RxContent, {
       'maxHeight',
       'width',
       'maxWidth',
-      'isChromeless'
+      'isChromeless',
+      'className'
     ].indexOf(prop) === -1
 })<
   Pick<

--- a/packages/modal-dialog/src/types.ts
+++ b/packages/modal-dialog/src/types.ts
@@ -27,6 +27,7 @@ type ControlledModalProps =
 export type BaseModalProps = ControlledModalProps & {
   ['data-testid']?: string;
   children: ReactChild | null | (ReactChild | null)[];
+  className?: string;
   footerContent?: JSX.Element | string;
   hasCloseIcon?: boolean;
   hasKeylines?: boolean;


### PR DESCRIPTION
Passthrough the classname on the component to the modal content. this is
necessary as when triggered, the modal is not a child of the
`tablekit-modal-dialog` component, so it's not accessible to style as a
descendant
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-modal-dialog@3.1.3-canary.92.2153021765.0
  # or 
  yarn add @tablecheck/tablekit-modal-dialog@3.1.3-canary.92.2153021765.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
