### PR TITLE
fix(input): label prop can be react node or string

### DIFF
--- a/packages/input/src/Label.tsx
+++ b/packages/input/src/Label.tsx
@@ -16,8 +16,8 @@ type PropsType = {
   /** show a style indicating that the label is for a required field */
   isRequired?: boolean;
 
-  /** the label text to display */
-  label: string;
+  /** the label text to display, note that the label's direct parent is a span so passing in a block element such as a div might throw warnings */
+  label: string | ReactNode;
 
   /** onclick handler */
   onClick?: (event: MouseEvent | KeyboardEvent) => void;


### PR DESCRIPTION
fixes #96
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-calendar@3.1.3-canary.97.2311629718.0
  npm install @tablecheck/tablekit-input-button@2.1.3-canary.97.2311629718.0
  npm install @tablecheck/tablekit-input@2.1.3-canary.97.2311629718.0
  npm install @tablecheck/tablekit-password-field@2.1.4-canary.97.2311629718.0
  npm install @tablecheck/tablekit-phone-input@3.1.3-canary.97.2311629718.0
  npm install @tablecheck/tablekit-radio@2.1.3-canary.97.2311629718.0
  npm install @tablecheck/tablekit-select@2.1.3-canary.97.2311629718.0
  npm install @tablecheck/tablekit-textarea@2.1.3-canary.97.2311629718.0
  # or 
  yarn add @tablecheck/tablekit-calendar@3.1.3-canary.97.2311629718.0
  yarn add @tablecheck/tablekit-input-button@2.1.3-canary.97.2311629718.0
  yarn add @tablecheck/tablekit-input@2.1.3-canary.97.2311629718.0
  yarn add @tablecheck/tablekit-password-field@2.1.4-canary.97.2311629718.0
  yarn add @tablecheck/tablekit-phone-input@3.1.3-canary.97.2311629718.0
  yarn add @tablecheck/tablekit-radio@2.1.3-canary.97.2311629718.0
  yarn add @tablecheck/tablekit-select@2.1.3-canary.97.2311629718.0
  yarn add @tablecheck/tablekit-textarea@2.1.3-canary.97.2311629718.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
