### PR TITLE
feat(tablekit-react): add radio component

### DIFF
--- a/system/react/src/components/Radio.stories.tsx
+++ b/system/react/src/components/Radio.stories.tsx
@@ -1,0 +1,29 @@
+import { Story } from '@storybook/react';
+
+import { classlessSelector, classySelector, Radio } from './Radio';
+
+const contentVariants = ['Default', 'Hover', 'Focus', 'Disabled'] as const;
+
+export default {
+  title: 'TableKit/Radio',
+  component: Radio,
+  parameters: {
+    classySelector,
+    classlessSelector,
+    variants: contentVariants.length
+  }
+};
+
+export const AllVariants: Story = () => (
+  <>
+    {[true, false].map((isChecked) =>
+      contentVariants.map((variant) => (
+        <Radio
+          data-pseudo={variant.toLowerCase()}
+          disabled={variant === 'Disabled'}
+          checked={isChecked}
+        />
+      ))
+    )}
+  </>
+);

--- a/system/react/src/components/Radio.ts
+++ b/system/react/src/components/Radio.ts
@@ -1,0 +1,74 @@
+import styled from '@emotion/styled';
+
+export const classlessSelector = 'input[type="radio"]';
+export const classySelector = '.radio';
+
+export const Radio = styled.input<{ type?: 'radio' }>`
+  --radio-size: 20px;
+  appearance: none;
+  border-radius: 100%;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  height: var(--radio-size);
+  margin: 2px;
+  max-height: var(--radio-size);
+  max-width: var(--radio-size);
+  min-height: var(--radio-size);
+  min-width: var(--radio-size);
+  position: relative;
+  transition: all 80ms linear;
+  width: var(--radio-size);
+
+  &:before {
+    --radio-inner-size: 9px;
+    background-color: transparent;
+    border-radius: 100%;
+    content: '';
+    height: var(--radio-inner-size);
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    transition: all 80ms linear;
+    width: var(--radio-inner-size);
+  }
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--text);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible:after {
+    display: block;
+    content: '';
+    border: 2px solid var(--focus);
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    left: -6px;
+    bottom: -6px;
+    border-radius: 100%;
+  }
+
+  &:checked {
+    border-color: var(--text);
+  }
+
+  &:checked:before {
+    background-color: var(--text);
+  }
+
+  &:disabled {
+    border-color: var(--border-transparent);
+    background-color: var(--surface-disabled);
+    cursor: not-allowed;
+  }
+`;
+
+Radio.defaultProps = {
+  type: 'radio'
+};

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -24,6 +24,7 @@ export {
   baseStylesObject as menuListStylesObject,
   MenuList
 } from './components/MenuList';
+export { Radio } from './components/Radio';
 export { ScrollShadow } from './components/ScrollShadow';
 export { globalThemeVars, Select } from './components/Select';
 export { Skeleton } from './components/Skeleton';


### PR DESCRIPTION

<img width="354" alt="Screen Shot 2022-09-22 at 13 41 04" src="https://user-images.githubusercontent.com/56089945/191726396-b4d9c71b-922a-41b4-98d6-5f53404a1ec1.png">


Resolves https://github.com/tablecheck/tablekit/issues/106
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.1.0-canary.122.3126475364.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.122.3126475364.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.122.3126475364.0
  # or 
  yarn add @tablecheck/tablekit-css@2.1.0-canary.122.3126475364.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.122.3126475364.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.122.3126475364.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
