### PR TITLE
feat(tablekit-react): add button group component

### DIFF
--- a/system/react/src/components/ButtonGroup.stories.tsx
+++ b/system/react/src/components/ButtonGroup.stories.tsx
@@ -1,0 +1,81 @@
+import { FavoriteFilled } from '@carbon/icons-react';
+import { Meta, Story } from '@storybook/react';
+
+import { ButtonGroup, classySelector } from './ButtonGroup';
+
+const contentVariants = [
+  'Default',
+  'Hover',
+  'Focus',
+  'Focus Before',
+  'Focus After',
+  'Active'
+] as const;
+
+export default {
+  title: 'TableKit/ButtonGroup',
+  component: ButtonGroup,
+  parameters: {
+    classySelector,
+    variants: contentVariants,
+    chromatic: { viewports: [1500] }
+  }
+} as Meta;
+
+export const AllVariants: Story = () => (
+  <>
+    {[-1, 0, 1, 2].map((selectedIndex) =>
+      contentVariants.map((variant) => (
+        <ButtonGroup>
+          {['icon', 'text', 'icon+text'].map((type, index) => {
+            let dataPseudo = 'default';
+            switch (variant) {
+              case 'Default':
+              case 'Hover':
+              case 'Active':
+                if (selectedIndex === -1 && index === 1) {
+                  dataPseudo = variant.toLowerCase();
+                }
+                break;
+              case 'Focus After':
+              case 'Focus Before':
+              case 'Focus': {
+                if (
+                  selectedIndex !== -1 &&
+                  ((variant === 'Focus' && index === selectedIndex) ||
+                    (variant === 'Focus Before' &&
+                      index === selectedIndex - 1) ||
+                    (variant === 'Focus After' && index === selectedIndex + 1))
+                ) {
+                  dataPseudo = 'focus';
+                } else if (
+                  selectedIndex === -1 &&
+                  ((variant === 'Focus' && index === 1) ||
+                    (variant === 'Focus Before' && index === 0) ||
+                    (variant === 'Focus After' && index === 2))
+                ) {
+                  dataPseudo = 'focus';
+                }
+                break;
+              }
+            }
+            return (
+              <button
+                /* eslint-disable-next-line react/no-array-index-key */
+                key={`${selectedIndex}_${type}_${variant}_${index}`}
+                type="button"
+                data-pseudo={dataPseudo}
+                data-selected={index === selectedIndex}
+              >
+                {['icon', 'icon+text'].includes(type) ? (
+                  <FavoriteFilled size={20} />
+                ) : null}
+                {['text', 'icon+text'].includes(type) ? 'Text' : null}
+              </button>
+            );
+          })}
+        </ButtonGroup>
+      ))
+    )}
+  </>
+);

--- a/system/react/src/components/ButtonGroup.ts
+++ b/system/react/src/components/ButtonGroup.ts
@@ -1,0 +1,123 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const classySelector = '.button-group';
+
+const stateBoxShadow = {
+  default:
+    'inset 0 1px var(--border), ' +
+    'inset -1px 0 var(--border), ' +
+    'inset 0 -1px var(--border)',
+  selected:
+    '-1px 0 var(--border-active), ' +
+    'inset 0 1px var(--border-active), ' +
+    'inset -1px 0 var(--border-active), ' +
+    'inset 0 -1px var(--border-active)'
+};
+
+export const baseStyles = css`
+  position: relative;
+  display: flex;
+  flex-flow: row wrap;
+
+  & > * {
+    position: relative;
+    display: grid;
+    grid-gap: var(--spacing-l2);
+    grid-auto-flow: column;
+    align-items: center;
+    justify-content: center;
+    font: var(--body-1);
+    padding: var(--spacing-l3) var(--spacing-l4);
+    text-decoration: none;
+    white-space: nowrap;
+    outline: none;
+    cursor: pointer;
+    color: var(--text);
+    background: var(--grey-100);
+    box-shadow: ${stateBoxShadow.default};
+
+    &:hover,
+    &:focus-visible {
+      background: var(--surface-hover);
+    }
+
+    &:focus-visible {
+      outline: none;
+      &:after {
+        content: '';
+        position: absolute;
+        z-index: 1;
+        top: -4px;
+        bottom: -4px;
+        left: -5px;
+        right: -4px;
+        border-radius: var(--border-radius-small);
+        border: 2px solid var(--focus, hsla(219, 78.5%, 52.5%, 1));
+      }
+
+      &[data-selected='true'] {
+        box-shadow: ${stateBoxShadow.selected};
+      }
+    }
+
+    &:active {
+      background: var(--surface-active);
+    }
+
+    &[data-selected='true'] {
+      background: var(--surface);
+      box-shadow: ${stateBoxShadow.selected};
+    }
+
+    &:first-child {
+      border-top-left-radius: var(--border-radius-small);
+      border-bottom-left-radius: var(--border-radius-small);
+      box-shadow: inset 0 0 0 1px var(--border);
+
+      &:focus-visible {
+        &:after {
+          left: -4px;
+        }
+
+        &[data-selected='true'] {
+          box-shadow: inset 0 0 0 1px var(--border-active);
+        }
+      }
+
+      &:active {
+        background: var(--surface-active);
+      }
+
+      &[data-selected='true'] {
+        background: var(--surface);
+        box-shadow: inset 0 0 0 1px var(--border-active);
+      }
+    }
+
+    &:last-child {
+      border-top-right-radius: var(--border-radius-small);
+      border-bottom-right-radius: var(--border-radius-small);
+      box-shadow: ${stateBoxShadow.default};
+
+      &:focus-visible {
+        &[data-selected='true'] {
+          box-shadow: ${stateBoxShadow.selected};
+        }
+      }
+
+      &:active {
+        background: var(--surface-active);
+      }
+
+      &[data-selected='true'] {
+        background: var(--surface);
+        box-shadow: ${stateBoxShadow.selected};
+      }
+    }
+  }
+`;
+
+export const ButtonGroup = styled.div`
+  ${baseStyles};
+`;

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -6,6 +6,7 @@ export { BadgeBase, VariantBadges, Badge } from './components/Badge';
 export type { Props as BadgeProps, BadgeVariant } from './components/Badge';
 export { ButtonBase, VariantButtons, Button } from './components/Button';
 export type { ButtonVariant } from './components/Button';
+export { ButtonGroup } from './components/ButtonGroup';
 export { Checkbox } from './components/Checkbox';
 export { Input, InputWithIcons } from './components/Input';
 export type { Props as InputProps } from './components/Input';


### PR DESCRIPTION
Resolves #101.

![image](https://user-images.githubusercontent.com/19342294/193241683-24432e1b-c0e0-4d9c-8588-18596f08da32.png)
![image](https://user-images.githubusercontent.com/19342294/193241728-99962bfc-0fbd-4b0c-a371-958e9dba7a25.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.1.0-canary.123.3180154964.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.123.3180154964.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.123.3180154964.0
  # or 
  yarn add @tablecheck/tablekit-css@2.1.0-canary.123.3180154964.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.123.3180154964.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.123.3180154964.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
