### PR TITLE
fix(tablekit-react): add cursor changes on checkbox

### DIFF
--- a/system/react/src/components/Checkbox.ts
+++ b/system/react/src/components/Checkbox.ts
@@ -3,9 +3,10 @@ import styled from '@emotion/styled';
 export const classlessSelector = 'input[type="checkbox"]';
 export const classySelector = '.checkbox';
 
-export const Checkbox = styled.input<{ type: 'checkbox' }>`
+export const Checkbox = styled.input<{ type?: 'checkbox' }>`
   --checkbox-size: 20px;
   appearance: none;
+  cursor: pointer;
   position: relative;
   margin: 2px;
   padding: 0;
@@ -18,7 +19,9 @@ export const Checkbox = styled.input<{ type: 'checkbox' }>`
   border: 2px solid var(--border);
   border-radius: 2px;
   transition: all 80ms linear;
-  &:hover {
+
+  &:hover,
+  &:focus-visible {
     border-color: var(--text);
   }
   &:focus {
@@ -43,6 +46,7 @@ export const Checkbox = styled.input<{ type: 'checkbox' }>`
   &:disabled {
     border-color: var(--border-transparent);
     background-color: var(--text-disabled);
+    cursor: not-allowed;
   }
   &:before {
     --c: var(--text-contrast); /* Color */
@@ -78,3 +82,7 @@ export const Checkbox = styled.input<{ type: 'checkbox' }>`
     background-repeat: no-repeat;
   }
 `;
+
+Checkbox.defaultProps = {
+  type: 'checkbox'
+};

--- a/system/react/src/components/Checkboxes.stories.tsx
+++ b/system/react/src/components/Checkboxes.stories.tsx
@@ -19,7 +19,6 @@ export const Variants: Story = () => (
     {[true, false].map((isChecked) =>
       contentVariants.map((variant) => (
         <Checkbox
-          type="checkbox"
           data-pseudo={variant.toLowerCase()}
           disabled={variant.toLowerCase() === 'disabled'}
           checked={isChecked}


### PR DESCRIPTION
- Cursor changed to pointer/not-allowed in appropriate cases
- Do not oblige to explicitly pass to component `type="checkbox"`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.0.1-canary.125.3126719355.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.125.3126719355.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.125.3126719355.0
  # or 
  yarn add @tablecheck/tablekit-css@2.0.1-canary.125.3126719355.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.125.3126719355.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.125.3126719355.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
