### PR TITLE
feat(tablekit-react): add toggle component

### DIFF
--- a/system/react/src/components/Toggle.stories.tsx
+++ b/system/react/src/components/Toggle.stories.tsx
@@ -1,0 +1,46 @@
+import { Story } from '@storybook/react';
+import * as React from 'react';
+
+import { classySelector, Toggle } from './Toggle';
+
+const contentVariants = ['Default', 'Disabled', 'Hover', 'Focus'] as const;
+
+export default {
+  title: 'TableKit/Toggle',
+  component: Toggle,
+  parameters: {
+    classySelector,
+    variants: contentVariants
+  }
+};
+
+export const AllVariants: Story = () => (
+  <>
+    {[false, true].map((state) =>
+      [undefined, 'small'].map((size) =>
+        contentVariants.map((variant) => (
+          <Toggle
+            type="checkbox"
+            data-pseudo={variant.toLowerCase()}
+            data-size={size}
+            disabled={variant === 'Disabled'}
+            checked={state}
+          />
+        ))
+      )
+    )}
+    {[undefined, 'small'].map((size) =>
+      contentVariants.map((variant) => (
+        <Toggle
+          type="checkbox"
+          data-pseudo={variant.toLowerCase()}
+          data-size={size}
+          disabled={variant === 'Disabled'}
+          ref={(ref) => {
+            if (ref) ref.indeterminate = true;
+          }}
+        />
+      ))
+    )}
+  </>
+);

--- a/system/react/src/components/Toggle.ts
+++ b/system/react/src/components/Toggle.ts
@@ -1,0 +1,121 @@
+import styled from '@emotion/styled';
+
+export const classySelector = 'input[type="checkbox"].toggle';
+
+export const Toggle = styled.input<{ type: 'checkbox' }>`
+  position: relative;
+  appearance: none;
+  border: 2px solid var(--border);
+  border-radius: 70px;
+  width: 68px;
+  height: 38px;
+  transition: all 80ms linear;
+  cursor: pointer;
+
+  &:before {
+    --size: 26px;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: var(--spacing-l1);
+    content: '';
+    height: var(--size);
+    width: var(--size);
+    border-radius: 50%;
+    background-color: var(--text);
+  }
+
+  &:disabled:before {
+    background-color: var(--text-disabled);
+  }
+
+  &:hover {
+    background-color: var(--surface-hover-transparent);
+
+    &:disabled:before {
+      background-color: var(--text);
+    }
+  }
+
+  &:hover:disabled {
+    background-color: var(--surface);
+
+    &:before {
+      background-color: var(--text-disabled);
+    }
+  }
+
+  &:checked,
+  &:indeterminate {
+    background-color: var(--primary);
+    border: 2px solid var(--border-transparent);
+
+    &:before {
+      background-color: var(--surface);
+    }
+
+    &:hover {
+      background-color: var(--primary-hover);
+    }
+
+    &:disabled {
+      background-color: var(--surface-disabled);
+      border: 2px solid var(--border);
+
+      &:hover {
+        &::before {
+          background-color: var(--surface);
+        }
+      }
+    }
+  }
+
+  &:checked:before {
+    right: var(--spacing-l1);
+    left: auto;
+  }
+
+  &:indeterminate {
+    &:before {
+      width: 36px;
+      height: 6px;
+      background-color: var(--surface);
+      border-radius: 50px;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+    &:after {
+      content: '';
+      position: absolute;
+      top: -4px;
+      bottom: -4px;
+      left: -4px;
+      right: -4px;
+      border: 2px solid var(--focus);
+      border-radius: 99px;
+    }
+  }
+
+  &[data-size='small'] {
+    width: 50px;
+    height: 26px;
+
+    &:before {
+      --size: 18px;
+    }
+
+    &:indeterminate:before {
+      width: 26px;
+      height: 4px;
+    }
+  }
+`;
+
+Toggle.defaultProps = {
+  type: 'checkbox'
+};

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -39,6 +39,7 @@ export {
 export { TabButton } from './components/TabButton';
 export { Tabs, TabContent } from './components/Tabs';
 export { ThemeProvider } from './components/ThemeProvider';
+export { Toggle } from './components/Toggle';
 export { tooltip } from './selectorStyles/tooltip';
 export { constants } from './themeVariables/constants';
 export { ltrSupport } from './themeVariables/ltrSupport';


### PR DESCRIPTION
Completes #105

<img width="229" alt="Screenshot 2022-10-13 at 22 20 21" src="https://user-images.githubusercontent.com/59263605/195693227-b8670ecf-90aa-484a-86ec-03d54a0efa9c.png">
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.1.0-canary.129.3428418383.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.129.3428418383.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.129.3428418383.0
  # or 
  yarn add @tablecheck/tablekit-css@2.1.0-canary.129.3428418383.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.129.3428418383.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.129.3428418383.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
