### PR TITLE
fix: add header to story preview to show variant title

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -129,7 +129,6 @@ const StoryWrapper = styled.div`
   grid-template-rows: max-content;
   align-items: stretch;
   min-width: 100vw;
-
   & > * {
     display: flex;
     flex-direction: column;
@@ -164,6 +163,18 @@ export const decorators = [
     const isDark = useDarkMode();
     const direction = getDirection();
     const { classlessSelector, classySelector } = context.parameters;
+    const gridStyles = {
+      '--variants': context.parameters.variants?.length || 1
+    };
+    const storyHeader =
+      context.parameters.variants?.length > 1 &&
+      context.parameters.variants.every(
+        (variant: any) => typeof variant === 'string'
+      )
+        ? context.parameters.variants.map((variant: string) => (
+            <b>{variant.charAt(0).toUpperCase() + variant.slice(1)}</b>
+          ))
+        : null;
     return (
       <CacheProvider value={emotionCache}>
         <StoryWrapper>
@@ -190,12 +201,8 @@ export const decorators = [
                   ) : null}
                 </Selectors>
               ) : null}
-              <Grid
-                ref={handleGridRef}
-                style={
-                  { '--variants': context.parameters.variants || 1 } as any
-                }
-              >
+              <Grid ref={handleGridRef} style={gridStyles as any}>
+                {storyHeader}
                 {story()}
               </Grid>
             </ThemeInner>
@@ -207,12 +214,8 @@ export const decorators = [
             isRtl={direction === 'rtl'}
           >
             <ThemeInner>
-              <Grid
-                ref={handleGridRef}
-                style={
-                  { '--variants': context.parameters.variants || 1 } as any
-                }
-              >
+              <Grid ref={handleGridRef} style={gridStyles as any}>
+                {storyHeader}
                 {story()}
               </Grid>
             </ThemeInner>

--- a/system/react/src/components/Badge.stories.tsx
+++ b/system/react/src/components/Badge.stories.tsx
@@ -6,7 +6,7 @@ import { Badge, variants, classySelector } from './Badge';
 export default {
   title: 'TableKit/Badges',
   component: Badge,
-  parameters: { variants: variants.length, classySelector }
+  parameters: { variants, classySelector }
 } as Meta;
 
 export const AllVariants: Story = () => (

--- a/system/react/src/components/Buttons.stories.tsx
+++ b/system/react/src/components/Buttons.stories.tsx
@@ -13,7 +13,7 @@ import {
 export default {
   title: 'TableKit/Buttons',
   component: Button,
-  parameters: { variants: variants.length, classlessSelector, classySelector }
+  parameters: { variants, classlessSelector, classySelector }
 } as Meta;
 
 export const AllVariants = () => (

--- a/system/react/src/components/Checkboxes.stories.tsx
+++ b/system/react/src/components/Checkboxes.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'TableKit/Checkbox',
   component: Checkbox,
   parameters: {
-    variants: contentVariants.length,
+    variants: contentVariants,
     classlessSelector,
     classySelector
   }

--- a/system/react/src/components/InputLikeButton.stories.tsx
+++ b/system/react/src/components/InputLikeButton.stories.tsx
@@ -13,7 +13,7 @@ const contentVariants = [
 export default {
   title: 'TableKit/InputLikeButton',
   component: InputLikeButton,
-  parameters: { variants: contentVariants.length, classySelector }
+  parameters: { variants: contentVariants, classySelector }
 } as Meta;
 
 export const Variants: Story = () => (

--- a/system/react/src/components/Inputs.stories.tsx
+++ b/system/react/src/components/Inputs.stories.tsx
@@ -19,7 +19,7 @@ export default {
   title: 'TableKit/Input',
   component: Input,
   parameters: {
-    variants: contentVariants.length,
+    variants: contentVariants,
     classlessSelector,
     classySelector
   }
@@ -29,7 +29,6 @@ export const Variants: Story = () => (
   <>
     {contentVariants.map((props) => (
       <>
-        {' '}
         <Input {...props} placeholder="Placeholder" />
         <InputWithIcons {...props}>
           <input placeholder="Placeholder" />

--- a/system/react/src/components/Radio.stories.tsx
+++ b/system/react/src/components/Radio.stories.tsx
@@ -10,7 +10,7 @@ export default {
   parameters: {
     classySelector,
     classlessSelector,
-    variants: contentVariants.length
+    variants: contentVariants
   }
 };
 

--- a/system/react/src/components/ScrollShadow.stories.tsx
+++ b/system/react/src/components/ScrollShadow.stories.tsx
@@ -9,7 +9,7 @@ import {
 export default {
   title: 'TableKit/ScrollShadow',
   component: CoreScrollShadow,
-  parameters: { variants: 3, classySelector }
+  parameters: { variants: ['Start', 'Center', 'End'], classySelector }
 } as Meta;
 
 const ScrollShadow = styled(CoreScrollShadow)`

--- a/system/react/src/components/Select.stories.tsx
+++ b/system/react/src/components/Select.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'TableKit/Select',
   component: Select,
   parameters: {
-    variants: contentVariants.length,
+    variants: contentVariants,
     classlessSelector,
     classySelector
   }


### PR DESCRIPTION

![Снимок экрана 2022-09-30 в 13 12 37](https://user-images.githubusercontent.com/19342294/193248378-42304b9c-8441-4c2c-966e-898cae0e1a24.png)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.0.1-canary.133.3172001754.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.133.3172001754.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.133.3172001754.0
  # or 
  yarn add @tablecheck/tablekit-css@2.0.1-canary.133.3172001754.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.133.3172001754.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.133.3172001754.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
