### PR TITLE
ci: skip chromatic on draft pull requests

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -1,6 +1,12 @@
 name: Pull Request Workflow
 
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 concurrency:
   # Here the group is defined by the head_ref of the PR
@@ -140,6 +146,7 @@ jobs:
   chromatic:
     runs-on: ubuntu-latest
     needs: [test, lint]
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2


### PR DESCRIPTION
To reduce the number of chromatic runs we are going to not run chromatic until the PR is marked as ready

Ref: https://github.com/reviewdog/action-eslint/issues/29#issuecomment-985939887