### PR TITLE
fix: add button sizes

### DIFF
--- a/system/react/src/components/Button.ts
+++ b/system/react/src/components/Button.ts
@@ -17,14 +17,16 @@ export const classySelector = '.btn';
 export const baseStyles = css`
   position: relative;
   display: grid;
-  padding: 12px 20px;
+  padding: 10px var(--spacing-l3);
   grid-gap: var(--spacing-l2);
   grid-auto-flow: column;
+  align-content: center;
   cursor: pointer;
+  height: 40px;
 
   font-weight: 500;
   font-size: 16px;
-  line-height: 24px;
+  line-height: 20px;
   border-radius: var(--border-radius-small);
 
   align-items: center;
@@ -40,9 +42,23 @@ export const baseStyles = css`
       bottom: -4px;
       left: -4px;
       right: -4px;
-      border-radius: var(--border-radius-large);
+      border-radius: 6px;
       border: 2px solid var(--focus, hsla(219, 78.5%, 52.5%, 1));
     }
+  }
+
+  &[data-size='small'] {
+    padding: var(--spacing-l2);
+    font-size: 14px;
+    line-height: 16px;
+    height: 32px;
+  }
+
+  &[data-size='large'] {
+    padding: 14px var(--spacing-l4);
+    font-size: 16px;
+    line-height: 20px;
+    height: 48px;
   }
 `;
 
@@ -67,6 +83,7 @@ export const variants = [
 ] as const;
 
 export type ButtonVariant = typeof variants[number];
+export type ButtonSize = 'small' | 'medium' | 'large';
 
 const variantStyles: Record<ButtonVariant, SerializedStyles> = {
   primary: css`
@@ -152,7 +169,7 @@ const coreStyles = css`
     z-index: 2;
   }
   &[aria-busy='true'] {
-    ${spinnerElementStyles}
+    ${spinnerElementStyles};
     color: transparent;
   }
   &[aria-busy='true']:before {
@@ -184,6 +201,7 @@ export const VariantButtons = variants.reduce(
 
 export const Button = styled(ButtonBase)<{
   'data-variant'?: ButtonVariant;
+  'data-size'?: ButtonSize;
   'aria-busy'?: boolean;
 }>`
   &:not([data-variant]) {

--- a/system/react/src/components/Buttons.stories.tsx
+++ b/system/react/src/components/Buttons.stories.tsx
@@ -18,31 +18,34 @@ export default {
 
 export const AllVariants = () => (
   <>
-    {(
-      [
-        'Button',
-        'Icon Left',
-        'Icon Right',
-        'Active',
-        'Hover',
-        'Focus',
-        'Loading',
-        'Disabled'
-      ] as const
-    ).map((status) =>
-      variants.map((variant) => (
-        <Button
-          key={`${status}_${variant}`}
-          aria-busy={status === 'Loading'}
-          disabled={status === 'Disabled'}
-          data-variant={variant}
-          data-pseudo={status.toLowerCase()}
-        >
-          {status === 'Icon Left' ? <Globe size={20} /> : null}
-          {status}
-          {status === 'Icon Right' ? <ChevronDown size={20} /> : null}
-        </Button>
-      ))
+    {(['small', 'medium', 'large'] as const).map((size) =>
+      (
+        [
+          'Button',
+          'Icon Left',
+          'Icon Right',
+          'Active',
+          'Hover',
+          'Focus',
+          'Loading',
+          'Disabled'
+        ] as const
+      ).map((status) =>
+        variants.map((variant) => (
+          <Button
+            key={`${status}_${variant}`}
+            aria-busy={status === 'Loading'}
+            disabled={status === 'Disabled'}
+            data-variant={variant}
+            data-pseudo={status.toLowerCase()}
+            data-size={size}
+          >
+            {status === 'Icon Left' ? <Globe size={20} /> : null}
+            {status} {size}
+            {status === 'Icon Right' ? <ChevronDown size={20} /> : null}
+          </Button>
+        ))
+      )
     )}
   </>
 );

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -6,7 +6,7 @@ export { BadgeBase, VariantBadges, Badge } from './components/Badge';
 export type { Props as BadgeProps, BadgeVariant } from './components/Badge';
 export { Banner } from './components/Banner';
 export { ButtonBase, VariantButtons, Button } from './components/Button';
-export type { ButtonVariant } from './components/Button';
+export type { ButtonVariant, ButtonSize } from './components/Button';
 export { ButtonGroup } from './components/ButtonGroup';
 export { Checkbox } from './components/Checkbox';
 export { Input, InputWithIcons } from './components/Input';


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.0.1-canary.148.3562692881.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.148.3562692881.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.148.3562692881.0
  # or 
  yarn add @tablecheck/tablekit-css@2.0.1-canary.148.3562692881.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.148.3562692881.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.148.3562692881.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
