### PR TITLE
fix(tablekit-react-select): fix react-select Option component

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -861,6 +861,38 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-38900?component-type=npm&component-name=decode-uri-component&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/json5@2.2.1",
+      "description": "JSON for humans.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/json5@2.2.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-46175",
+          "title": "[CVE-2022-46175] CWE-1321",
+          "description": "JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 versions 1.0.2, 2.2.2, and later.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-46175 for details",
+          "cvssScore": 8.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-46175",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-46175?component-type=npm&component-name=json5&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/json5@1.0.1",
+      "description": "JSON for humans.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/json5@1.0.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-46175",
+          "title": "[CVE-2022-46175] CWE-1321",
+          "description": "JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 versions 1.0.2, 2.2.2, and later.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-46175 for details",
+          "cvssScore": 8.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-46175",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-46175?component-type=npm&component-name=json5&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1043,6 +1075,9 @@
     },
     {
       "id": "CVE-2022-38900"
+    },
+    {
+      "id": "CVE-2022-46175"
     }
   ]
 }

--- a/system/react-select/src/index.tsx
+++ b/system/react-select/src/index.tsx
@@ -231,11 +231,11 @@ export function useReactSelectConfig<
 
     if (!hideSelectedOptions) {
       selectComponents.Option = function (props) {
-        const { isSelected, label } = props;
+        const { isSelected, children } = props;
         return (
           <reactSelectComponents.Option {...props}>
             <Checkbox checked={isSelected} readOnly />
-            <span>{label}</span>
+            {children}
           </reactSelectComponents.Option>
         );
       };


### PR DESCRIPTION
Use children instead of span to preserve option props.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.0.1-canary.153.3848164403.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.153.3848164403.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.153.3848164403.0
  # or 
  yarn add @tablecheck/tablekit-css@2.0.1-canary.153.3848164403.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.153.3848164403.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.153.3848164403.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
