### PR TITLE
fix: add chip component

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -893,6 +893,22 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-46175?component-type=npm&component-name=json5&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/http-cache-semantics@4.1.0",
+      "description": "Parses Cache-Control and other headers. Helps building correct HTTP caches and proxies",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/http-cache-semantics@4.1.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25881",
+          "title": "[CVE-2022-25881] CWE-1333",
+          "description": "This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "cve": "CVE-2022-25881",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25881?component-type=npm&component-name=http-cache-semantics&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1078,6 +1094,9 @@
     },
     {
       "id": "CVE-2022-46175"
+    },
+    {
+      "id": "CVE-2022-25881"
     }
   ]
 }

--- a/system/react/src/components/Chip.stories.tsx
+++ b/system/react/src/components/Chip.stories.tsx
@@ -1,0 +1,49 @@
+import { Story, Meta } from '@storybook/react';
+
+import { Chip, classySelector } from './Chip';
+import { ChipRow } from './ChipRow';
+
+const contentVariants = [
+  'Default',
+  'Selected',
+  'Hover',
+  'Focus',
+  'Disabled',
+  'Active'
+] as const;
+
+export default {
+  title: 'TableKit/Chip',
+  parameters: {
+    classySelector,
+    variants: contentVariants,
+    chromatic: { viewports: [1500] }
+  }
+} as Meta;
+
+const chips = ['State', 'Default'];
+
+export const Default: Story<any> = () => (
+  <>
+    {(['small', undefined] as const).map((size) => (
+      <>
+        {contentVariants.map((variant) => (
+          <ChipRow role="tablist">
+            {chips.map((name, i) => (
+              <Chip
+                key={name}
+                data-variant={i === 0 && variant}
+                data-size={size}
+                disabled={i === 0 && variant === 'Disabled'}
+                aria-selected={i === 0 && variant === 'Selected'}
+                data-pseudo={i === 0 && variant.toLowerCase()}
+              >
+                {name} {size}
+              </Chip>
+            ))}
+          </ChipRow>
+        ))}
+      </>
+    ))}
+  </>
+);

--- a/system/react/src/components/Chip.tsx
+++ b/system/react/src/components/Chip.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+
+export const classySelector = '.chip';
+
+export const Chip = styled.button<{
+  role?: 'tab';
+  'aria-selected'?: boolean;
+  'aria-controls'?: string;
+  'data-size'?: 'small' | 'regular';
+}>`
+  --padding-y: 12px;
+  --padding-x: 16px;
+  padding: calc(var(--padding-y) - 2px) calc(var(--padding-x) - 2px);
+  position: relative;
+  text-decoration: none !important;
+  color: var(--text);
+  border-radius: var(--border-radius-full);
+  border: 2px solid var(--border-transparent);
+  white-space: nowrap;
+  &:hover {
+    background-color: var(--surface-hover);
+    cursor: pointer;
+  }
+  &:focus:not(:focus-visible),
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--focus, hsla(219, 78.5%, 52.5%, 1));
+  }
+  &:active {
+    background-color: var(--surface-active);
+  }
+  &[data-size='small'] {
+    --padding-x: 14px;
+    --padding-y: 6px;
+  }
+  &[aria-selected='true'] {
+    background-color: var(--secondary);
+    border-color: var(--secondary);
+    color: var(--text-contrast);
+  }
+  &:disabled {
+    color: var(--text-disabled);
+    background-color: var(--surface-disabled);
+    cursor: not-allowed;
+  }
+`;

--- a/system/react/src/components/ChipRow.tsx
+++ b/system/react/src/components/ChipRow.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const classySelector = '.chip-row';
+
+export const ChipRow = styled.div<{
+  role?: 'tablist';
+}>`
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-l2);
+`;

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -10,6 +10,8 @@ export type { ButtonVariant } from './components/Button';
 export { ButtonGroup } from './components/ButtonGroup';
 export { Checkbox } from './components/Checkbox';
 export { CheckboxLabel, RadioLabel } from './components/CheckboxLabel';
+export { Chip } from './components/Chip';
+export { ChipRow } from './components/ChipRow';
 export {
   IconButtonBase,
   VariantIconButtons,

--- a/system/react/src/themeVariables/constants.ts
+++ b/system/react/src/themeVariables/constants.ts
@@ -45,6 +45,7 @@ export const constants = css`
   :root {
     --border-radius-small: 4px;
     --border-radius-large: 8px;
+    --border-radius-full: 9999px;
     --input-height: 48px;
     --spacing-l1: 4px;
     --spacing-l2: 8px;


### PR DESCRIPTION
Adding chip component and stories

resolves: #104
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.1.0-canary.155.4101537640.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.155.4101537640.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.155.4101537640.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.155.4101537640.0
  # or 
  yarn add @tablecheck/tablekit-css@2.1.0-canary.155.4101537640.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.155.4101537640.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.155.4101537640.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.155.4101537640.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
