### PR TITLE
feat(tablekit-react): add checkbox-label component

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -193,7 +193,12 @@ export const decorators = [
       { value: classlessSelector, name: 'Classless Selector' },
       { value: classySelector, name: 'Classy Selector' },
       { value: packageName, name: 'Package Name' }
-    ].filter(({ value }) => !!value);
+    ]
+      .filter(({ value }) => !!value)
+      .map(({ value, ...rest }) => ({
+        ...rest,
+        value: Array.isArray(value) ? value.join(', ') : value
+      }));
     return (
       <CacheProvider value={emotionCache}>
         <StoryWrapper>

--- a/system/react/scripts/updateFromFigma.mjs
+++ b/system/react/scripts/updateFromFigma.mjs
@@ -108,7 +108,9 @@ while (greys.length) {
 
 delete colorVars.greys;
 
-const fileContent = `import { css } from '@emotion/react';
+const fileContent = `// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable max-lines */
+import { css } from '@emotion/react';
 
 /**
  * DO NOT EDIT; File is generated from figma, see './updateFromFigma.mjs' for update instructions

--- a/system/react/src/components/Checkbox.stories.tsx
+++ b/system/react/src/components/Checkbox.stories.tsx
@@ -1,6 +1,10 @@
 import { Story, Meta } from '@storybook/react';
 
 import { Checkbox, classlessSelector, classySelector } from './Checkbox';
+import {
+  CheckboxLabel,
+  classySelector as labelSelector
+} from './CheckboxLabel';
 
 const contentVariants = ['Default', 'Hover', 'Focus', 'Disabled'] as const;
 
@@ -10,7 +14,7 @@ export default {
   parameters: {
     variants: contentVariants,
     classlessSelector,
-    classySelector
+    classySelector: [classySelector, labelSelector]
   }
 } as Meta;
 
@@ -18,11 +22,14 @@ export const Variants: Story = () => (
   <>
     {[true, false].map((isChecked) =>
       contentVariants.map((variant) => (
-        <Checkbox
-          data-pseudo={variant.toLowerCase()}
-          disabled={variant.toLowerCase() === 'disabled'}
-          checked={isChecked}
-        />
+        <CheckboxLabel>
+          <Checkbox
+            data-pseudo={variant.toLowerCase()}
+            disabled={variant.toLowerCase() === 'disabled'}
+            checked={isChecked}
+          />
+          {variant} {isChecked ? '☑' : '☐'}
+        </CheckboxLabel>
       ))
     )}
   </>

--- a/system/react/src/components/Checkbox.ts
+++ b/system/react/src/components/Checkbox.ts
@@ -20,23 +20,14 @@ export const Checkbox = styled.input<{ type?: 'checkbox' }>`
   border-radius: 2px;
   transition: all 80ms linear;
 
-  &:hover,
-  &:focus-visible {
+  &:hover {
     border-color: var(--text);
   }
   &:focus {
     outline: none;
   }
-  &:focus-visible:after {
-    display: block;
-    content: '';
-    border: 2px solid var(--focus);
-    position: absolute;
-    top: -6px;
-    right: -6px;
-    left: -6px;
-    bottom: -6px;
-    border-radius: 4px;
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--focus);
   }
   &:checked,
   &:indeterminate {

--- a/system/react/src/components/CheckboxLabel.ts
+++ b/system/react/src/components/CheckboxLabel.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const classySelector = 'label.checkbox, label.radio';
+
+export const CheckboxLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-l2);
+  cursor: pointer;
+  font: var(--body-1);
+`;
+
+export const RadioLabel = CheckboxLabel;

--- a/system/react/src/components/Radio.stories.tsx
+++ b/system/react/src/components/Radio.stories.tsx
@@ -1,5 +1,6 @@
 import { Story } from '@storybook/react';
 
+import { RadioLabel, classySelector as labelSelector } from './CheckboxLabel';
 import { classlessSelector, classySelector, Radio } from './Radio';
 
 const contentVariants = ['Default', 'Hover', 'Focus', 'Disabled'] as const;
@@ -8,7 +9,7 @@ export default {
   title: 'TableKit/Radio',
   component: Radio,
   parameters: {
-    classySelector,
+    classySelector: [classySelector, labelSelector],
     classlessSelector,
     variants: contentVariants
   }
@@ -18,11 +19,14 @@ export const AllVariants: Story = () => (
   <>
     {[true, false].map((isChecked) =>
       contentVariants.map((variant) => (
-        <Radio
-          data-pseudo={variant.toLowerCase()}
-          disabled={variant === 'Disabled'}
-          checked={isChecked}
-        />
+        <RadioLabel>
+          <Radio
+            data-pseudo={variant.toLowerCase()}
+            disabled={variant === 'Disabled'}
+            checked={isChecked}
+          />
+          {variant} {isChecked ? '☑' : '☐'}
+        </RadioLabel>
       ))
     )}
   </>

--- a/system/react/src/components/Radio.ts
+++ b/system/react/src/components/Radio.ts
@@ -7,7 +7,7 @@ export const Radio = styled.input<{ type?: 'radio' }>`
   --radio-size: 20px;
   appearance: none;
   border-radius: 100%;
-  border: 1px solid var(--border);
+  border: 2px solid var(--border);
   cursor: pointer;
   height: var(--radio-size);
   margin: 2px;
@@ -33,8 +33,7 @@ export const Radio = styled.input<{ type?: 'radio' }>`
     width: var(--radio-inner-size);
   }
 
-  &:hover,
-  &:focus-visible {
+  &:hover {
     border-color: var(--text);
   }
 
@@ -42,16 +41,8 @@ export const Radio = styled.input<{ type?: 'radio' }>`
     outline: none;
   }
 
-  &:focus-visible:after {
-    display: block;
-    content: '';
-    border: 2px solid var(--focus);
-    position: absolute;
-    top: -6px;
-    right: -6px;
-    left: -6px;
-    bottom: -6px;
-    border-radius: 100%;
+  &:focus-visible {
+    box-shadow: 0 0 0 2px var(--focus);
   }
 
   &:checked {

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -9,6 +9,7 @@ export { ButtonBase, VariantButtons, Button } from './components/Button';
 export type { ButtonVariant } from './components/Button';
 export { ButtonGroup } from './components/ButtonGroup';
 export { Checkbox } from './components/Checkbox';
+export { CheckboxLabel, RadioLabel } from './components/CheckboxLabel';
 export {
   IconButtonBase,
   VariantIconButtons,

--- a/system/react/src/themeVariables/theme.ts
+++ b/system/react/src/themeVariables/theme.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable max-lines */
 import { css } from '@emotion/react';
 
 /**
@@ -22,13 +24,21 @@ export const lightColors = css`
   --border-transparent: rgba(0, 0, 0, 0.1);
   --error: rgba(204, 0, 0, 1);
   --error-surface: rgba(254, 223, 223, 1);
+  --error-surface-hover: rgba(254, 205, 205, 1);
   --error-text: rgba(204, 0, 0, 1);
   --field: rgba(255, 255, 255, 1);
   --focus: rgba(0, 23, 231, 1);
   --info: rgba(0, 102, 204, 1);
   --info-surface: rgba(223, 239, 254, 1);
+  --info-surface-hover: rgba(205, 229, 254, 1);
   --info-text: rgba(0, 102, 204, 1);
-  --neutral-surface: rgba(249, 249, 249, 1);
+  --link: rgba(0, 102, 204, 1);
+  --link-disabled: rgba(206, 206, 206, 1);
+  --link-hover: rgba(27, 126, 225, 1);
+  --link-visited: rgba(200, 0, 204, 1);
+  --neutral: rgba(75, 75, 75, 1);
+  --neutral-surface: rgba(238, 238, 238, 1);
+  --neutral-surface-hover: rgba(229, 229, 229, 1);
   --neutral-text: rgba(75, 75, 75, 1);
   --secondary: rgba(41, 41, 41, 1);
   --secondary-active: rgba(75, 75, 75, 1);
@@ -36,6 +46,7 @@ export const lightColors = css`
   --secondary-surface: rgba(249, 249, 249, 1);
   --success: rgba(6, 121, 0, 1);
   --success-surface: rgba(233, 254, 223, 1);
+  --success-surface-hover: rgba(220, 254, 205, 1);
   --success-text: rgba(6, 121, 0, 1);
   --surface: rgba(255, 255, 255, 1);
   --surface-active: rgba(0, 0, 0, 0.14);
@@ -43,7 +54,7 @@ export const lightColors = css`
   --surface-alt-active: rgba(243, 242, 255, 1);
   --surface-alt-hover: rgba(249, 249, 249, 1);
   --surface-alt-hover-transparent: rgba(0, 0, 0, 0.03);
-  --surface-disabled: rgba(229, 229, 229, 1);
+  --surface-disabled: rgba(238, 238, 238, 1);
   --surface-hover: rgba(238, 238, 238, 1);
   --surface-hover-transparent: rgba(0, 0, 0, 0.06);
   --text: rgba(41, 41, 41, 1);
@@ -53,6 +64,7 @@ export const lightColors = css`
   --text-subtle: rgba(152, 152, 152, 1);
   --warning: rgba(232, 183, 47, 1);
   --warning-surface: rgba(255, 250, 223, 1);
+  --warning-surface-hover: rgba(255, 248, 212, 1);
   --warning-text: rgba(146, 107, 7, 1);
   --grey-950: rgba(30, 30, 30, 1);
   --grey-900: rgba(41, 41, 41, 1);
@@ -75,13 +87,21 @@ export const lightColorsObject = {
   'border-transparent': 'rgba(0, 0, 0, 0.1)',
   error: 'rgba(204, 0, 0, 1)',
   'error-surface': 'rgba(254, 223, 223, 1)',
+  'error-surface-hover': 'rgba(254, 205, 205, 1)',
   'error-text': 'rgba(204, 0, 0, 1)',
   field: 'rgba(255, 255, 255, 1)',
   focus: 'rgba(0, 23, 231, 1)',
   info: 'rgba(0, 102, 204, 1)',
   'info-surface': 'rgba(223, 239, 254, 1)',
+  'info-surface-hover': 'rgba(205, 229, 254, 1)',
   'info-text': 'rgba(0, 102, 204, 1)',
-  'neutral-surface': 'rgba(249, 249, 249, 1)',
+  link: 'rgba(0, 102, 204, 1)',
+  'link-disabled': 'rgba(206, 206, 206, 1)',
+  'link-hover': 'rgba(27, 126, 225, 1)',
+  'link-visited': 'rgba(200, 0, 204, 1)',
+  neutral: 'rgba(75, 75, 75, 1)',
+  'neutral-surface': 'rgba(238, 238, 238, 1)',
+  'neutral-surface-hover': 'rgba(229, 229, 229, 1)',
   'neutral-text': 'rgba(75, 75, 75, 1)',
   secondary: 'rgba(41, 41, 41, 1)',
   'secondary-active': 'rgba(75, 75, 75, 1)',
@@ -89,6 +109,7 @@ export const lightColorsObject = {
   'secondary-surface': 'rgba(249, 249, 249, 1)',
   success: 'rgba(6, 121, 0, 1)',
   'success-surface': 'rgba(233, 254, 223, 1)',
+  'success-surface-hover': 'rgba(220, 254, 205, 1)',
   'success-text': 'rgba(6, 121, 0, 1)',
   surface: 'rgba(255, 255, 255, 1)',
   'surface-active': 'rgba(0, 0, 0, 0.14)',
@@ -96,7 +117,7 @@ export const lightColorsObject = {
   'surface-alt-active': 'rgba(243, 242, 255, 1)',
   'surface-alt-hover': 'rgba(249, 249, 249, 1)',
   'surface-alt-hover-transparent': 'rgba(0, 0, 0, 0.03)',
-  'surface-disabled': 'rgba(229, 229, 229, 1)',
+  'surface-disabled': 'rgba(238, 238, 238, 1)',
   'surface-hover': 'rgba(238, 238, 238, 1)',
   'surface-hover-transparent': 'rgba(0, 0, 0, 0.06)',
   text: 'rgba(41, 41, 41, 1)',
@@ -106,6 +127,7 @@ export const lightColorsObject = {
   'text-subtle': 'rgba(152, 152, 152, 1)',
   warning: 'rgba(232, 183, 47, 1)',
   'warning-surface': 'rgba(255, 250, 223, 1)',
+  'warning-surface-hover': 'rgba(255, 248, 212, 1)',
   'warning-text': 'rgba(146, 107, 7, 1)',
   'grey-950': 'rgba(30, 30, 30, 1)',
   'grey-900': 'rgba(41, 41, 41, 1)',
@@ -129,13 +151,21 @@ export const darkColors = css`
   --border-transparent: rgba(255, 255, 255, 0.17);
   --error: rgba(239, 72, 72, 1);
   --error-surface: rgba(140, 0, 0, 1);
+  --error-surface-hover: rgba(159, 0, 0, 1);
   --error-text: rgba(254, 223, 223, 1);
   --field: rgba(41, 41, 41, 1);
   --focus: rgba(104, 119, 253, 1);
   --info: rgba(72, 155, 239, 1);
   --info-surface: rgba(0, 70, 140, 1);
+  --info-surface-hover: rgba(0, 88, 175, 1);
   --info-text: rgba(223, 239, 254, 1);
+  --link: rgba(72, 155, 239, 1);
+  --link-disabled: rgba(152, 152, 152, 1);
+  --link-hover: rgba(27, 126, 225, 1);
+  --link-visited: rgba(181, 11, 215, 1);
+  --neutral: rgba(102, 102, 102, 1);
   --neutral-surface: rgba(58, 58, 58, 1);
+  --neutral-surface-hover: rgba(41, 41, 41, 1);
   --neutral-text: rgba(219, 219, 219, 1);
   --secondary: rgba(255, 255, 255, 1);
   --secondary-active: rgba(206, 206, 206, 1);
@@ -143,6 +173,7 @@ export const darkColors = css`
   --secondary-surface: rgba(41, 41, 41, 1);
   --success: rgba(20, 175, 0, 1);
   --success-surface: rgba(3, 102, 0, 1);
+  --success-surface-hover: rgba(6, 121, 0, 1);
   --success-text: rgba(233, 254, 223, 1);
   --surface: rgba(18, 18, 18, 1);
   --surface-active: rgba(255, 255, 255, 0.17);
@@ -150,7 +181,7 @@ export const darkColors = css`
   --surface-alt-active: rgba(56, 39, 80, 1);
   --surface-alt-hover: rgba(41, 41, 41, 1);
   --surface-alt-hover-transparent: rgba(255, 255, 255, 0.09);
-  --surface-disabled: rgba(102, 102, 102, 1);
+  --surface-disabled: rgba(75, 75, 75, 1);
   --surface-hover: rgba(41, 41, 41, 1);
   --surface-hover-transparent: rgba(255, 255, 255, 0.09);
   --text: rgba(253, 253, 253, 1);
@@ -160,6 +191,7 @@ export const darkColors = css`
   --text-subtle: rgba(191, 191, 191, 1);
   --warning: rgba(239, 194, 72, 1);
   --warning-surface: rgba(140, 103, 0, 1);
+  --warning-surface-hover: rgba(159, 116, 0, 1);
   --warning-text: rgba(254, 246, 223, 1);
   --grey-950: rgba(253, 253, 253, 1);
   --grey-900: rgba(249, 249, 249, 1);
@@ -182,13 +214,21 @@ export const darkColorsObject = {
   'border-transparent': 'rgba(255, 255, 255, 0.17)',
   error: 'rgba(239, 72, 72, 1)',
   'error-surface': 'rgba(140, 0, 0, 1)',
+  'error-surface-hover': 'rgba(159, 0, 0, 1)',
   'error-text': 'rgba(254, 223, 223, 1)',
   field: 'rgba(41, 41, 41, 1)',
   focus: 'rgba(104, 119, 253, 1)',
   info: 'rgba(72, 155, 239, 1)',
   'info-surface': 'rgba(0, 70, 140, 1)',
+  'info-surface-hover': 'rgba(0, 88, 175, 1)',
   'info-text': 'rgba(223, 239, 254, 1)',
+  link: 'rgba(72, 155, 239, 1)',
+  'link-disabled': 'rgba(152, 152, 152, 1)',
+  'link-hover': 'rgba(27, 126, 225, 1)',
+  'link-visited': 'rgba(181, 11, 215, 1)',
+  neutral: 'rgba(102, 102, 102, 1)',
   'neutral-surface': 'rgba(58, 58, 58, 1)',
+  'neutral-surface-hover': 'rgba(41, 41, 41, 1)',
   'neutral-text': 'rgba(219, 219, 219, 1)',
   secondary: 'rgba(255, 255, 255, 1)',
   'secondary-active': 'rgba(206, 206, 206, 1)',
@@ -196,6 +236,7 @@ export const darkColorsObject = {
   'secondary-surface': 'rgba(41, 41, 41, 1)',
   success: 'rgba(20, 175, 0, 1)',
   'success-surface': 'rgba(3, 102, 0, 1)',
+  'success-surface-hover': 'rgba(6, 121, 0, 1)',
   'success-text': 'rgba(233, 254, 223, 1)',
   surface: 'rgba(18, 18, 18, 1)',
   'surface-active': 'rgba(255, 255, 255, 0.17)',
@@ -203,7 +244,7 @@ export const darkColorsObject = {
   'surface-alt-active': 'rgba(56, 39, 80, 1)',
   'surface-alt-hover': 'rgba(41, 41, 41, 1)',
   'surface-alt-hover-transparent': 'rgba(255, 255, 255, 0.09)',
-  'surface-disabled': 'rgba(102, 102, 102, 1)',
+  'surface-disabled': 'rgba(75, 75, 75, 1)',
   'surface-hover': 'rgba(41, 41, 41, 1)',
   'surface-hover-transparent': 'rgba(255, 255, 255, 0.09)',
   text: 'rgba(253, 253, 253, 1)',
@@ -213,6 +254,7 @@ export const darkColorsObject = {
   'text-subtle': 'rgba(191, 191, 191, 1)',
   warning: 'rgba(239, 194, 72, 1)',
   'warning-surface': 'rgba(140, 103, 0, 1)',
+  'warning-surface-hover': 'rgba(159, 116, 0, 1)',
   'warning-text': 'rgba(254, 246, 223, 1)',
   'grey-950': 'rgba(253, 253, 253, 1)',
   'grey-900': 'rgba(249, 249, 249, 1)',
@@ -234,13 +276,15 @@ export const brandColors = css`
   --primary-active: rgba(109, 48, 189, 1);
   --primary-hover: rgba(109, 48, 189, 1);
   --primary-surface: rgba(230, 219, 243, 1);
+  --primary-text: rgba(255, 255, 255, 1);
 `;
 
 export const brandColorsObject = {
   primary: 'rgba(121, 53, 210, 1)',
   'primary-active': 'rgba(109, 48, 189, 1)',
   'primary-hover': 'rgba(109, 48, 189, 1)',
-  'primary-surface': 'rgba(230, 219, 243, 1)'
+  'primary-surface': 'rgba(230, 219, 243, 1)',
+  'primary-text': 'rgba(255, 255, 255, 1)'
 };
 
 export const utilityColors = css`


### PR DESCRIPTION
Utility component that would be regularly used with the checkbox component (screenshot is outdated - fixes removed the gap between focus ring and border which is also applied to radio)

![CleanShot 2023-01-31 at 12 33 17](https://user-images.githubusercontent.com/1085899/215656652-f2435008-68a8-4ee1-8dfe-9b97a11276d8.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.1.0-canary.156.4050716870.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.156.4050716870.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.156.4050716870.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.156.4050716870.0
  # or 
  yarn add @tablecheck/tablekit-css@2.1.0-canary.156.4050716870.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.156.4050716870.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.156.4050716870.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.156.4050716870.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
