### PR TITLE
fix(tablekit-react): add missing variants for badge

### DIFF
--- a/system/react/src/components/Badge.ts
+++ b/system/react/src/components/Badge.ts
@@ -34,7 +34,14 @@ export const BadgeBase = styled.span<Props>`
 /**
  * @deprecated This is intented for internal use only, changes here have no effect
  */
-export const variants = ['success', 'warning', 'info', 'error'] as const;
+export const variants = [
+  'success',
+  'warning',
+  'info',
+  'error',
+  'neutral',
+  'purple'
+] as const;
 
 export type BadgeVariant = typeof variants[number];
 

--- a/system/react/src/themeVariables/theme.ts
+++ b/system/react/src/themeVariables/theme.ts
@@ -40,6 +40,8 @@ export const lightColors = css`
   --neutral-surface: rgba(238, 238, 238, 1);
   --neutral-surface-hover: rgba(229, 229, 229, 1);
   --neutral-text: rgba(75, 75, 75, 1);
+  --purple-surface: rgba(245, 216, 255, 1);
+  --purple-text: rgba(113, 0, 153, 1);
   --secondary: rgba(41, 41, 41, 1);
   --secondary-active: rgba(75, 75, 75, 1);
   --secondary-hover: rgba(102, 102, 102, 1);
@@ -103,6 +105,8 @@ export const lightColorsObject = {
   'neutral-surface': 'rgba(238, 238, 238, 1)',
   'neutral-surface-hover': 'rgba(229, 229, 229, 1)',
   'neutral-text': 'rgba(75, 75, 75, 1)',
+  'purple-surface': 'rgba(245, 216, 255, 1)',
+  'purple-text': 'rgba(113, 0, 153, 1)',
   secondary: 'rgba(41, 41, 41, 1)',
   'secondary-active': 'rgba(75, 75, 75, 1)',
   'secondary-hover': 'rgba(102, 102, 102, 1)',
@@ -167,6 +171,8 @@ export const darkColors = css`
   --neutral-surface: rgba(58, 58, 58, 1);
   --neutral-surface-hover: rgba(41, 41, 41, 1);
   --neutral-text: rgba(219, 219, 219, 1);
+  --purple-surface: rgba(113, 0, 153, 1);
+  --purple-text: rgba(245, 216, 255, 1);
   --secondary: rgba(255, 255, 255, 1);
   --secondary-active: rgba(206, 206, 206, 1);
   --secondary-hover: rgba(229, 229, 229, 1);
@@ -230,6 +236,8 @@ export const darkColorsObject = {
   'neutral-surface': 'rgba(58, 58, 58, 1)',
   'neutral-surface-hover': 'rgba(41, 41, 41, 1)',
   'neutral-text': 'rgba(219, 219, 219, 1)',
+  'purple-surface': 'rgba(113, 0, 153, 1)',
+  'purple-text': 'rgba(245, 216, 255, 1)',
   secondary: 'rgba(255, 255, 255, 1)',
   'secondary-active': 'rgba(206, 206, 206, 1)',
   'secondary-hover': 'rgba(229, 229, 229, 1)',


### PR DESCRIPTION
<img width="577" alt="image" src="https://user-images.githubusercontent.com/3442546/217412665-243381e1-1a1f-4db3-954e-2a9216faddef.png">

No Issue
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.1.0-canary.157.4120774475.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.157.4120774475.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.157.4120774475.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.157.4120774475.0
  # or 
  yarn add @tablecheck/tablekit-css@2.1.0-canary.157.4120774475.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.157.4120774475.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.157.4120774475.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.157.4120774475.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
