### PR TITLE
fix(tablekit-react-select): disabled should be uninteractable

### DIFF
--- a/system/react-select/src/ReactSelect.stories.tsx
+++ b/system/react-select/src/ReactSelect.stories.tsx
@@ -16,6 +16,7 @@ const contentVariants = [
   },
   { title: 'Focus', isInternalFocused: true },
   { title: 'Disabled', isDisabled: true },
+  { title: 'Disabled with value', isDisabled: true, defaultValue: options[0] },
   { title: 'Error', isInvalid: true }
 ] as const;
 

--- a/system/react-select/src/index.tsx
+++ b/system/react-select/src/index.tsx
@@ -137,27 +137,15 @@ export function useReactSelectConfig<
       ),
       // eslint-disable-next-line @typescript-eslint/naming-convention
       SelectContainer: (props) => {
-        const {
-          children,
-          className,
-          cx,
-          getStyles,
-          innerProps,
-          isDisabled: isComponentDisabled,
-          isRtl
-        } = props;
+        const { children, className, getStyles, innerProps, isDisabled } =
+          props;
         return (
           <div
             css={css(getStyles('container', props))}
-            className={cx(
-              {
-                '--is-disabled': isComponentDisabled,
-                '--is-rtl': isRtl
-              },
-              className
-            )}
+            className={className}
             {...innerProps}
             data-testid={dataTestId}
+            aria-disabled={isDisabled}
           >
             <div
               css={css`
@@ -230,7 +218,7 @@ export function useReactSelectConfig<
     };
 
     if (!hideSelectedOptions) {
-      selectComponents.Option = function (props) {
+      selectComponents.Option = function Option(props) {
         const { isSelected, children } = props;
         return (
           <reactSelectComponents.Option {...props}>
@@ -242,17 +230,20 @@ export function useReactSelectConfig<
     }
 
     return selectComponents;
-  }, [dataTestId, isInvalid, icon, isClearable, hideSelectedOptions]);
+  }, [hideSelectedOptions, isInvalid, icon, dataTestId, isMulti, isClearable]);
   const stylesObject = React.useMemo<StylesConfig<OptionType, IsMulti>>(
     () => ({
-      container: (styles) => ({
+      container: (styles, { isDisabled, isRtl }) => ({
         ...styles,
         display: 'grid !important',
         justifyContent: 'stretch',
         pointerEvents: 'auto',
         height: 'auto',
         width: 'auto',
-        minWidth: isCompact ? 'auto' : 180
+        minWidth: isCompact ? 'auto' : 180,
+        '--is-disabled': isDisabled,
+        '--is-rtl': isRtl,
+        'pointer-events': isDisabled ? 'none' : 'auto'
       }),
       control: (styles, { isFocused, isDisabled }) => {
         const isLargeBorder =
@@ -435,13 +426,14 @@ export function useReactSelectConfig<
       })
     }),
     [
-      borderRadii,
-      borderSides,
-      icon,
       isCompact,
+      isInternalFocused,
       isInvalid,
-      isMulti,
       theme.isRtl,
+      borderSides,
+      isMulti,
+      borderRadii,
+      icon,
       hideSelectedOptions
     ]
   );


### PR DESCRIPTION
Minor lint and a11y fixes found while investigating the issue.

Related to MOPS-808
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.0.1-canary.158.4121536367.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.158.4121536367.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.158.4121536367.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.158.4121536367.0
  # or 
  yarn add @tablecheck/tablekit-css@2.0.1-canary.158.4121536367.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.158.4121536367.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.158.4121536367.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.158.4121536367.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
