### PR TITLE
fix(tablekit-phone-input): remove RTL

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -178,6 +178,1129 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/849e9fed-44e8-4593-a4ca-61026c4b454f?component-type=npm&component-name=ansi-html&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/node-fetch@2.6.7",
+      "description": "A light-weight module that brings window.fetch to node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/node-fetch@2.6.7?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2022-3677",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 3.7,
+          "cvssVector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-3677"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/core-js@3.26.0",
+      "description": "Standard library",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/core-js@3.26.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2023-0962",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2023-0962"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/json5@2.2.1",
+      "description": "JSON for humans.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/json5@2.2.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-46175",
+          "title": "[CVE-2022-46175] CWE-1321",
+          "description": "JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 versions 1.0.2, 2.2.2, and later.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-46175 for details",
+          "cvssScore": 8.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-46175",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-46175?component-type=npm&component-name=json5&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/unset-value@1.0.0",
+      "description": "Delete nested properties from an object using dot notation.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/unset-value@1.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-0459",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 9.4,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-0459"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/decode-uri-component@0.2.0",
+      "description": "A better decodeURIComponent",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/decode-uri-component@0.2.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-38900",
+          "title": "[CVE-2022-38900] CWE-20: Improper Input Validation",
+          "description": "decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-38900",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-38900?component-type=npm&component-name=decode-uri-component&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/execa@1.0.0",
+      "description": "Process execution for humans",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/execa@1.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2019-0206",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2019-0206"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/loader-utils@2.0.3",
+      "description": "utils for webpack loaders",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/loader-utils@2.0.3?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-37599",
+          "title": "[CVE-2022-37599] CWE-Other",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37599",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37599?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2022-37603",
+          "title": "[CVE-2022-37603] CWE-1333",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37603",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37603?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/express@4.18.2",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/express@4.18.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2012-0022",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2012-0022"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/loader-utils@1.4.0",
+      "description": "utils for webpack loaders",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/loader-utils@1.4.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-37599",
+          "title": "[CVE-2022-37599] CWE-Other",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37599",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37599?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2022-37601",
+          "title": "[CVE-2022-37601] CWE-1321",
+          "description": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-37601",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37601?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2022-37603",
+          "title": "[CVE-2022-37603] CWE-1333",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37603",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37603?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/json5@1.0.1",
+      "description": "JSON for humans.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/json5@1.0.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-46175",
+          "title": "[CVE-2022-46175] CWE-1321",
+          "description": "JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 versions 1.0.2, 2.2.2, and later.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-46175 for details",
+          "cvssScore": 8.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-46175",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-46175?component-type=npm&component-name=json5&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/trim@0.0.1",
+      "description": "Trim string whitespace",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/trim@0.0.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2020-7753",
+          "title": "[CVE-2020-7753] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "All versions of package trim are vulnerable to Regular Expression Denial of Service (ReDoS) via trim().",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2020-7753",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2020-7753?component-type=npm&component-name=trim&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/postcss@7.0.39",
+      "description": "Tool for transforming styles with JS plugins",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/postcss@7.0.39?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-0563",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 6.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-0563"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/clean-css@4.2.4",
+      "description": "A well-tested CSS minifier",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/clean-css@4.2.4?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-1523",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-1523"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/glob-parent@3.1.0",
+      "description": "Extract the non-magic parent path from a glob string.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/glob-parent@3.1.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2020-28469",
+          "title": "[CVE-2020-28469] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "This affects the package glob-parent before 5.1.2. The enclosure regex used to check for strings ending in enclosure containing path separator.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2020-28469",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2020-28469?component-type=npm&component-name=glob-parent&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/request@2.88.2",
+      "description": "Simplified HTTP request client.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/request@2.88.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2017-0655",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 5.9,
+          "cvssVector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2017-0655"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/ws@5.2.3",
+      "description": "Simple to use, blazing fast and thoroughly tested websocket client and server for Node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/ws@5.2.3?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-32640",
+          "title": "[CVE-2021-32640] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "ws is an open source WebSocket client and server library for Node.js. A specially crafted value of the `Sec-Websocket-Protocol` header can be used to significantly slow down a ws server. The vulnerability has been fixed in ws@7.4.6 (https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff). In vulnerable versions of ws, the issue can be mitigated by reducing the maximum allowed length of the request headers using the [`--max-http-header-size=size`](https://nodejs.org/api/cli.html#cli_max_http_header_size_size) and/or the [`maxHeaderSize`](https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener) options.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "cve": "CVE-2021-32640",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-32640?component-type=npm&component-name=ws&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/node-forge@0.10.0",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/node-forge@0.10.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-0122",
+          "title": "[CVE-2022-0122] CWE-601: URL Redirection to Untrusted Site ('Open Redirect')",
+          "description": "forge is vulnerable to URL Redirection to Untrusted Site",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cve": "CVE-2022-0122",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-0122?component-type=npm&component-name=node-forge&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2022-24771",
+          "title": "[CVE-2022-24771] CWE-347: Improper Verification of Cryptographic Signature",
+          "description": "Forge (also called `node-forge`) is a native implementation of Transport Layer Security in JavaScript. Prior to version 1.3.0, RSA PKCS#1 v1.5 signature verification code is lenient in checking the digest algorithm structure. This can allow a crafted structure that steals padding bytes and uses unchecked portion of the PKCS#1 encoded message to forge a signature when a low public exponent is being used. The issue has been addressed in `node-forge` version 1.3.0. There are currently no known workarounds.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "cve": "CVE-2022-24771",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-24771?component-type=npm&component-name=node-forge&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2022-24772",
+          "title": "[CVE-2022-24772] CWE-347: Improper Verification of Cryptographic Signature",
+          "description": "Forge (also called `node-forge`) is a native implementation of Transport Layer Security in JavaScript. Prior to version 1.3.0, RSA PKCS#1 v1.5 signature verification code does not check for tailing garbage bytes after decoding a `DigestInfo` ASN.1 structure. This can allow padding bytes to be removed and garbage data added to forge a signature when a low public exponent is being used. The issue has been addressed in `node-forge` version 1.3.0. There are currently no known workarounds.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "cve": "CVE-2022-24772",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-24772?component-type=npm&component-name=node-forge&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2022-24773",
+          "title": "[CVE-2022-24773] CWE-347: Improper Verification of Cryptographic Signature",
+          "description": "Forge (also called `node-forge`) is a native implementation of Transport Layer Security in JavaScript. Prior to version 1.3.0, RSA PKCS#1 v1.5 signature verification code does not properly check `DigestInfo` for a proper ASN.1 structure. This can lead to successful verification with signatures that contain invalid structures but a valid digest. The issue has been addressed in `node-forge` version 1.3.0. There are currently no known workarounds.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cve": "CVE-2022-24773",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-24773?component-type=npm&component-name=node-forge&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "sonatype-2022-0218",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-0218"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/ws@6.2.2",
+      "description": "Simple to use, blazing fast and thoroughly tested websocket client and server for Node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/ws@6.2.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-32640",
+          "title": "[CVE-2021-32640] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "ws is an open source WebSocket client and server library for Node.js. A specially crafted value of the `Sec-Websocket-Protocol` header can be used to significantly slow down a ws server. The vulnerability has been fixed in ws@7.4.6 (https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff). In vulnerable versions of ws, the issue can be mitigated by reducing the maximum allowed length of the request headers using the [`--max-http-header-size=size`](https://nodejs.org/api/cli.html#cli_max_http_header_size_size) and/or the [`maxHeaderSize`](https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener) options.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "cve": "CVE-2021-32640",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-32640?component-type=npm&component-name=ws&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/remove-markdown@0.3.0",
+      "description": "Remove Markdown formatting from text",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/remove-markdown@0.3.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2019-0106",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2019-0106"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/http-cache-semantics@4.1.0",
+      "description": "Parses Cache-Control and other headers. Helps building correct HTTP caches and proxies",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/http-cache-semantics@4.1.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25881",
+          "title": "[CVE-2022-25881] CWE-1333",
+          "description": "This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25881",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25881?component-type=npm&component-name=http-cache-semantics&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/shelljs@0.8.5",
+      "description": "Portable Unix shell commands for Node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/shelljs@0.8.5?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2014-0038",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 8.8,
+          "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2014-0038"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/got@9.6.0",
+      "description": "Human-friendly and powerful HTTP request library for Node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/got@9.6.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-33987",
+          "title": "[CVE-2022-33987] CWE-601: URL Redirection to Untrusted Site ('Open Redirect')",
+          "description": "The got package before 12.1.0 (also fixed in 11.8.5) for Node.js allows a redirect to a UNIX socket.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-33987 for details",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cve": "CVE-2022-33987",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-33987?component-type=npm&component-name=got&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/react@18.2.0",
+      "description": "React is a JavaScript library for building user interfaces.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/react@18.2.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2017-0717",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 4.7,
+          "cvssVector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2017-0717"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/shell-quote@1.7.2",
+      "description": "quote and parse shell commands",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/shell-quote@1.7.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-42740",
+          "title": "[CVE-2021-42740] CWE-77: Improper Neutralization of Special Elements used in a Command ('Command Injection')",
+          "description": "The shell-quote package before 1.7.3 for Node.js allows command injection. An attacker can inject unescaped shell metacharacters through a regex designed to support Windows drive letters. If the output of this package is passed to a real shell as a quoted argument to a command with exec(), an attacker can inject arbitrary commands. This is because the Windows drive letter regex character class is {A-z] instead of the correct {A-Za-z]. Several shell metacharacters exist in the space between capital letter Z and lower case letter a, such as the backtick character.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2021-42740 for details",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2021-42740",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-42740?component-type=npm&component-name=shell-quote&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/ansi-html@0.0.7",
+      "description": "An elegant lib that converts the chalked (ANSI) text to HTML.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/ansi-html@0.0.7?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-23424",
+          "title": "[CVE-2021-23424] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "This affects all versions of package ansi-html. If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2021-23424",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-23424?component-type=npm&component-name=ansi-html&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/css-what@3.4.2",
+      "description": "a CSS selector parser",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/css-what@3.4.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-21222",
+          "title": "[CVE-2022-21222] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "The package css-what before 2.1.3 are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of insecure regular expression in the re_attr variable of index.js. The exploitation of this vulnerability could be triggered via the parse function.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-21222 for details",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-21222",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-21222?component-type=npm&component-name=css-what&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/nth-check@1.0.2",
+      "description": "performant nth-check parser & compiler",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/nth-check@1.0.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-3803",
+          "title": "[CVE-2021-3803] CWE-1333",
+          "description": "nth-check is vulnerable to Inefficient Regular Expression Complexity",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2021-3803",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-3803?component-type=npm&component-name=nth-check&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/browserslist@4.14.2",
+      "description": "Share target browsers between different front-end tools, like Autoprefixer, Stylelint and babel-env-preset",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/browserslist@4.14.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-23364",
+          "title": "[CVE-2021-23364] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "The package browserslist from 4.0.0 and before 4.16.5 are vulnerable to Regular Expression Denial of Service (ReDoS) during parsing of queries.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2021-23364 for details",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "cve": "CVE-2021-23364",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-23364?component-type=npm&component-name=browserslist&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/immer@8.0.1",
+      "description": "Create your next immutable state by mutating the current one",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/immer@8.0.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-23436",
+          "title": "[CVE-2021-23436] CWE-843: Access of Resource Using Incompatible Type ('Type Confusion')",
+          "description": "This affects the package immer before 9.0.6. A type confusion vulnerability can lead to a bypass of CVE-2020-28477 when the user-provided keys used in the path parameter are arrays. In particular, this bypass is possible because the condition (p === \"__proto__\" || p === \"constructor\") in applyPatches_ returns false if p is ['__proto__'] (or ['constructor']). The === operator (strict equality operator) returns false if the operands have different type.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2021-23436",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-23436?component-type=npm&component-name=immer&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2021-3757",
+          "title": "[CVE-2021-3757] CWE-1321",
+          "description": "immer is vulnerable to Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2021-3757",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-3757?component-type=npm&component-name=immer&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/loader-utils@2.0.0",
+      "description": "utils for webpack loaders",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/loader-utils@2.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-37599",
+          "title": "[CVE-2022-37599] CWE-Other",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37599",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37599?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2022-37601",
+          "title": "[CVE-2022-37601] CWE-1321",
+          "description": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-37601",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37601?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        },
+        {
+          "id": "CVE-2022-37603",
+          "title": "[CVE-2022-37603] CWE-1333",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37603",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37603?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/prompts@2.4.0",
+      "description": "Lightweight, beautiful and user-friendly prompts",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/prompts@2.4.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-3868",
+          "title": "[CVE-2021-3868] CWE-1333",
+          "description": "** REJECT ** DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: none. Reason: The CNA or individual who requested this candidate did not associate it with any vulnerability during 2021. Notes: none.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2021-3868",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-3868?component-type=npm&component-name=prompts&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/minimatch@3.0.4",
+      "description": "a glob matcher in javascript",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/minimatch@3.0.4?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-4879",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-4879"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/trim-newlines@1.0.0",
+      "description": "Trim newlines from the start and/or end of a string",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/trim-newlines@1.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-33623",
+          "title": "[CVE-2021-33623] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "The trim-newlines package before 3.0.1 and 4.x before 4.0.1 for Node.js has an issue related to regular expression denial-of-service (ReDoS) for the .end() method.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2021-33623",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-33623?component-type=npm&component-name=trim-newlines&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/node-fetch@2.6.1",
+      "description": "A light-weight module that brings window.fetch to node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/node-fetch@2.6.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-0235",
+          "title": "[CVE-2022-0235] CWE-200: Information Exposure",
+          "description": "node-fetch is vulnerable to Exposure of Sensitive Information to an Unauthorized Actor",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cve": "CVE-2022-0235",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-0235?component-type=npm&component-name=node-fetch&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/minimist@1.2.5",
+      "description": "parse argument options",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/minimist@1.2.5?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-44906",
+          "title": "[CVE-2021-44906] CWE-1321",
+          "description": "Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2021-44906",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-44906?component-type=npm&component-name=minimist&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/history@5.0.0",
+      "description": "Manage session history with JavaScript",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/history@5.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-0015",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-0015"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/history@5.2.0",
+      "description": "Manage session history with JavaScript",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/history@5.2.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-0015",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-0015"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/deep-object-diff@1.1.0",
+      "description": "Deep diffs two objects, including nested structures of arrays and objects, and return the difference.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/deep-object-diff@1.1.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-41713",
+          "title": "[CVE-2022-41713] CWE-1321",
+          "description": "deep-object-diff version 1.1.0 allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the '__proto__' property to be edited.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cve": "CVE-2022-41713",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-41713?component-type=npm&component-name=deep-object-diff&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/telejson@5.3.3",
+      "description": "A library for teleporting rich data to another place.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/telejson@5.3.3?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-1320",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 8.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-1320"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/markdown-to-jsx@7.1.5",
+      "description": "Convert markdown to JSX with ease for React and React-like projects. Super lightweight and highly configurable.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/markdown-to-jsx@7.1.5?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2020-1592",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 6.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2020-1592"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/prismjs@1.28.0",
+      "description": "Lightweight, robust, elegant syntax highlighting. A spin-off project from Dabblet.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/prismjs@1.28.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2020-1579",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2020-1579"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/prismjs@1.27.0",
+      "description": "Lightweight, robust, elegant syntax highlighting. A spin-off project from Dabblet.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/prismjs@1.27.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2020-1579",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2020-1579"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/express@4.17.2",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/express@4.17.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-24999",
+          "title": "[CVE-2022-24999] CWE-1321",
+          "description": "qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has \"deps: qs@6.9.7\" in its release description, is not vulnerable).\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-24999 for details",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-24999",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-24999?component-type=npm&component-name=express&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/qs@6.9.6",
+      "description": "A querystring parser that supports nesting and arrays, with a depth limit",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/qs@6.9.6?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-24999",
+          "title": "[CVE-2022-24999] CWE-1321",
+          "description": "qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has \"deps: qs@6.9.7\" in its release description, is not vulnerable).\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-24999 for details",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-24999",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-24999?component-type=npm&component-name=qs&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/ramda@0.21.0",
+      "description": "A practical functional library for JavaScript programmers.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/ramda@0.21.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-1736",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-1736"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/terser@4.8.0",
+      "description": "JavaScript parser, mangler/compressor and beautifier toolkit for ES6+",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/terser@4.8.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25858",
+          "title": "[CVE-2022-25858] CWE-1333",
+          "description": "The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-25858 for details",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25858",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25858?component-type=npm&component-name=terser&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/terser@5.10.0",
+      "description": "JavaScript parser, mangler/compressor and beautifier toolkit for ES6+",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/terser@5.10.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25858",
+          "title": "[CVE-2022-25858] CWE-1333",
+          "description": "The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-25858 for details",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25858",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25858?component-type=npm&component-name=terser&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/nanoid@3.1.30",
+      "description": "A tiny (108 bytes), secure URL-friendly unique string ID generator",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/nanoid@3.1.30?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-23566",
+          "title": "[CVE-2021-23566] CWE-704: Incorrect Type Conversion or Cast",
+          "description": "The package nanoid from 3.0.0 and before 3.1.31 are vulnerable to Information Exposure via the valueOf() function which allows to reproduce the last id generated.",
+          "cvssScore": 5.5,
+          "cvssVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+          "cve": "CVE-2021-23566",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-23566?component-type=npm&component-name=nanoid&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/nwsapi@2.2.0",
+      "description": "Fast CSS Selectors API Engine",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/nwsapi@2.2.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2022-3565",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 6.2,
+          "cvssVector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-3565"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/ansi-regex@4.1.0",
+      "description": "Regular expression for matching ANSI escape codes",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/ansi-regex@4.1.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2021-1169",
+          "title": "[sonatype-2021-1169] Unknown",
+          "description": "ansi-regex - Regular Expression Denial of Service (ReDoS) [CVE-2021-3807]\n\nansi-regex - Regular Expression Denial of Service (ReDoS) [CVE-2021-3807]",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2021-3807",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-1169?component-type=npm&component-name=ansi-regex&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/follow-redirects@1.14.7",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/follow-redirects@1.14.7?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-0536",
+          "title": "[CVE-2022-0536] CWE-200: Information Exposure",
+          "description": "Exposure of Sensitive Information to an Unauthorized Actor in NPM follow-redirects prior to 1.14.8.",
+          "cvssScore": 5.9,
+          "cvssVector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+          "cve": "CVE-2022-0536",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-0536?component-type=npm&component-name=follow-redirects&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/async@2.6.3",
+      "description": "Higher-order functions and common patterns for asynchronous code",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/async@2.6.3?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-43138",
+          "title": "[CVE-2021-43138] CWE-1321",
+          "description": "In Async before 2.6.4 and 3.x before 3.2.2, a malicious user can obtain privileges via the mapValues() method, aka lib/internal/iterator.js createObjectIterator prototype pollution.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2021-43138 for details",
+          "cvssScore": 7.8,
+          "cvssVector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2021-43138",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-43138?component-type=npm&component-name=async&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/eventsource@1.1.0",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/eventsource@1.1.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-1650",
+          "title": "[CVE-2022-1650] CWE-200: Information Exposure",
+          "description": "Exposure of Sensitive Information to an Unauthorized Actor in GitHub repository eventsource/eventsource prior to v2.0.2.",
+          "cvssScore": 9.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N",
+          "cve": "CVE-2022-1650",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-1650?component-type=npm&component-name=eventsource&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/url-parse@1.5.4",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/url-parse@1.5.4?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-0512",
+          "title": "[CVE-2022-0512] CWE-639: Authorization Bypass Through User-Controlled Key",
+          "description": "Authorization Bypass Through User-Controlled Key in NPM url-parse prior to 1.5.6.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-0512 for details",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cve": "CVE-2022-0512",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-0512?component-type=npm&component-name=url-parse&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        },
+        {
+          "id": "CVE-2022-0639",
+          "title": "[CVE-2022-0639] CWE-639: Authorization Bypass Through User-Controlled Key",
+          "description": "Authorization Bypass Through User-Controlled Key in NPM url-parse prior to 1.5.7.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cve": "CVE-2022-0639",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-0639?component-type=npm&component-name=url-parse&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        },
+        {
+          "id": "CVE-2022-0686",
+          "title": "[CVE-2022-0686] CWE-639: Authorization Bypass Through User-Controlled Key",
+          "description": "Authorization Bypass Through User-Controlled Key in NPM url-parse prior to 1.5.8.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-0686 for details",
+          "cvssScore": 9.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+          "cve": "CVE-2022-0686",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-0686?component-type=npm&component-name=url-parse&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        },
+        {
+          "id": "CVE-2022-0691",
+          "title": "[CVE-2022-0691] CWE-639: Authorization Bypass Through User-Controlled Key",
+          "description": "Authorization Bypass Through User-Controlled Key in NPM url-parse prior to 1.5.9.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-0691",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-0691?component-type=npm&component-name=url-parse&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/log4js@6.3.0",
+      "description": "Port of Log4js to work with node.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/log4js@6.3.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-21704",
+          "title": "[CVE-2022-21704] CWE-276: Incorrect Default Permissions",
+          "description": "log4js-node is a port of log4js to node.js. In affected versions default file permissions for log files created by the file, fileSync and dateFile appenders are world-readable (in unix). This could cause problems if log files contain sensitive information. This would affect any users that have not supplied their own permissions for the files via the mode parameter in the config. Users are advised to update.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-21704 for details",
+          "cvssScore": 5.5,
+          "cvssVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+          "cve": "CVE-2022-21704",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-21704?component-type=npm&component-name=log4js&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/streamroller@2.2.4",
+      "description": "file streams that roll over when size limits, or dates are reached",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/streamroller@2.2.4?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-21704",
+          "title": "[CVE-2022-21704] CWE-276: Incorrect Default Permissions",
+          "description": "log4js-node is a port of log4js to node.js. In affected versions default file permissions for log files created by the file, fileSync and dateFile appenders are world-readable (in unix). This could cause problems if log files contain sensitive information. This would affect any users that have not supplied their own permissions for the files via the mode parameter in the config. Users are advised to update.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-21704 for details",
+          "cvssScore": 5.5,
+          "cvssVector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+          "cve": "CVE-2022-21704",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-21704?component-type=npm&component-name=streamroller&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/xmldom@0.5.0",
+      "description": "A pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/xmldom@0.5.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-32796",
+          "title": "[CVE-2021-32796] CWE-116: Improper Encoding or Escaping of Output",
+          "description": "xmldom is an open source pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.6.0 and older do not correctly escape special characters when serializing elements removed from their ancestor. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This issue has been resolved in version 0.7.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cve": "CVE-2021-32796",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-32796?component-type=npm&component-name=xmldom&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        },
+        {
+          "id": "CVE-2022-37616",
+          "title": "[CVE-2022-37616] CWE-1321",
+          "description": "A prototype pollution vulnerability exists in the function copy in dom.js in the xmldom (published as @xmldom/xmldom) package before 0.8.3 for Node.js via the p variable. NOTE: the vendor states \"we are in the process of marking this report as invalid\"; however, some third parties takes the position that \"A prototype injection/Prototype pollution is not just when global objects are polluted with recursive merge or deep cloning but also when a target object is polluted.\"",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-37616",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37616?component-type=npm&component-name=xmldom&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        },
+        {
+          "id": "CVE-2022-39353",
+          "title": "[CVE-2022-39353] CWE-1288 CWE-20",
+          "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) `DOMParser` and `XMLSerializer` module. xmldom parses XML that is not well-formed because it contains multiple top level elements, and adds all root nodes to the `childNodes` collection of the `Document`, without reporting any error or throwing. This breaks the assumption that there is only a single root node in the tree, which led to issuance of CVE-2022-39299 as it is a potential issue for dependents. Update to @xmldom/xmldom@~0.7.7, @xmldom/xmldom@~0.8.4 (dist-tag latest) or @xmldom/xmldom@>=0.9.0-beta.4 (dist-tag next). As a workaround, please one of the following approaches depending on your use case: instead of searching for elements in the whole DOM, only search in the `documentElement`or reject a document with a document that has more then 1 `childNode`.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-39353",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-39353?component-type=npm&component-name=xmldom&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/lodash.template@4.5.0",
+      "description": "The Lodash method `_.template` exported as a module.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/lodash.template@4.5.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2021-23337",
+          "title": "[CVE-2021-23337] CWE-94: Improper Control of Generation of Code ('Code Injection')",
+          "description": "Lodash versions prior to 4.17.21 are vulnerable to Command Injection via the template function.",
+          "cvssScore": 7.2,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2021-23337",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2021-23337?component-type=npm&component-name=lodash.template&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/git-up@4.0.5",
+      "description": "A low level git url parser.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/git-up@4.0.5?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2022-3750",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 5.4,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-3750"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/parse-url@6.0.0",
+      "description": "An advanced url parser supporting git urls too.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/parse-url@6.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-2217",
+          "title": "[CVE-2022-2217] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+          "description": "Cross-site Scripting (XSS) - Generic in GitHub repository ionicabizau/parse-url prior to 7.0.0.",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cve": "CVE-2022-2217",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-2217?component-type=npm&component-name=parse-url&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/parse-path@4.0.3",
+      "description": "Parse paths (local paths, urls: ssh/git/etc)",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/parse-path@4.0.3?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-0624",
+          "title": "[CVE-2022-0624] CWE-639: Authorization Bypass Through User-Controlled Key",
+          "description": "Authorization Bypass Through User-Controlled Key in GitHub repository ionicabizau/parse-path prior to 5.0.0.",
+          "cvssScore": 7.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "cve": "CVE-2022-0624",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-0624?component-type=npm&component-name=parse-path&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        },
+        {
+          "id": "CVE-2022-2216",
+          "title": "[CVE-2022-2216] CWE-918: Server-Side Request Forgery (SSRF)",
+          "description": "Server-Side Request Forgery (SSRF) in GitHub repository ionicabizau/parse-url prior to 7.0.0.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-2216 for details",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-2216",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-2216?component-type=npm&component-name=parse-path&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        },
+        {
+          "id": "CVE-2022-2218",
+          "title": "[CVE-2022-2218] CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+          "description": "Cross-site Scripting (XSS) - Stored in GitHub repository ionicabizau/parse-url prior to 7.0.0.",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cve": "CVE-2022-2218",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-2218?component-type=npm&component-name=parse-path&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/parse-url@6.0.5",
+      "description": "An advanced url parser supporting git urls too.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/parse-url@6.0.5?utm_source=auditjs&utm_medium=integration&utm_content=4.0.25",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-2900",
+          "title": "[CVE-2022-2900] CWE-918: Server-Side Request Forgery (SSRF)",
+          "description": "Server-Side Request Forgery (SSRF) in GitHub repository ionicabizau/parse-url prior to 8.1.0.",
+          "cvssScore": 9.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+          "cve": "CVE-2022-2900",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-2900?component-type=npm&component-name=parse-url&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -213,6 +1336,215 @@
     },
     {
       "id": "849e9fed-44e8-4593-a4ca-61026c4b454f"
-    }
+    },
+    {
+      "id": "sonatype-2022-3677"
+    },
+    {
+      "id": "sonatype-2023-0962"
+    },
+    {
+      "id": "CVE-2022-46175"
+    },
+    {
+      "id": "sonatype-2021-0459"
+    },
+    {
+      "id": "CVE-2022-38900"
+    },
+    {
+      "id": "sonatype-2019-0206"
+    },
+    {
+      "id": "CVE-2022-37599"
+    },
+    {
+      "id": "CVE-2022-37603"
+    },
+    {
+      "id": "sonatype-2012-0022"
+    },
+    {
+      "id": "CVE-2022-37601"
+    },
+    {
+      "id": "CVE-2020-7753"
+    },
+    {
+      "id": "sonatype-2021-0563"
+    },
+    {
+      "id": "sonatype-2021-1523"
+    },
+    {
+      "id": "CVE-2020-28469"
+    },
+    {
+      "id": "sonatype-2017-0655"
+    },
+    {
+      "id": "CVE-2021-32640"
+    },
+    {
+      "id": "CVE-2022-0122"
+    },
+    {
+      "id": "CVE-2022-24771"
+    },
+    {
+      "id": "CVE-2022-24772"
+    },
+    {
+      "id": "CVE-2022-24773"
+    },
+    {
+      "id": "sonatype-2022-0218"
+    },
+    {
+      "id": "sonatype-2019-0106"
+    },
+    {
+      "id": "CVE-2022-25881"
+    },
+    {
+      "id": "sonatype-2014-0038"
+    },
+    {
+      "id": "CVE-2022-33987"
+    },
+    {
+      "id": "sonatype-2017-0717"
+    },
+    {
+      "id": "CVE-2021-42740"
+    },
+    {
+      "id": "CVE-2021-23424"
+    },
+    {
+      "id": "CVE-2022-21222"
+    },
+    {
+      "id": "CVE-2021-3803"
+    },
+    {
+      "id": "CVE-2021-23364"
+    },
+    {
+      "id": "CVE-2021-23436"
+    },
+    {
+      "id": "CVE-2021-3757"
+    },
+    {
+      "id": "CVE-2021-3868"
+    },
+    {
+      "id": "sonatype-2021-4879"
+    },
+    {
+      "id": "CVE-2021-33623"
+    },
+    {
+      "id": "CVE-2022-0235"
+    },
+    {
+      "id": "CVE-2021-44906"
+    },
+    {
+      "id": "sonatype-2021-0015"
+    },
+    {
+      "id": "CVE-2022-41713"
+    },
+    {
+      "id": "sonatype-2021-1320"
+    },
+    {
+      "id": "sonatype-2020-1592"
+    },
+    {
+      "id": "sonatype-2020-1579"
+    },
+    {
+      "id": "CVE-2022-24999"
+    },
+    {
+      "id": "sonatype-2021-1736"
+    },
+    {
+      "id": "CVE-2022-25858"
+    },
+    {
+      "id": "CVE-2021-23566"
+    },
+    {
+      "id": "sonatype-2022-3565"
+    },
+    {
+      "id": "sonatype-2021-1169"
+    },
+    {
+      "id": "CVE-2022-0536"
+    },
+    {
+      "id": "CVE-2021-43138"
+    },
+    {
+      "id": "CVE-2022-1650"
+    },
+    {
+      "id": "CVE-2022-0512"
+    },
+    {
+      "id": "CVE-2022-0639"
+    },
+    {
+      "id": "CVE-2022-0686"
+    },
+    {
+      "id": "CVE-2022-0691"
+    },
+    {
+      "id": "CVE-2022-21704"
+    },
+    {
+      "id": "CVE-2021-32796"
+    },
+    {
+      "id": "CVE-2022-37616"
+    },
+    {
+      "id": "CVE-2022-39353"
+    },
+    {
+      "id": "CVE-2021-23337"
+    },
+    {
+      "id": "sonatype-2022-3750"
+    },
+    {
+      "id": "CVE-2022-2217"
+    },
+    {
+      "id": "CVE-2022-0624"
+    },
+    {
+      "id": "CVE-2022-2216"
+    },
+    {
+      "id": "CVE-2022-2218"
+    },
+    {
+      "id": "CVE-2022-2900"
+    },
+    {
+      "id": "CWE-23"
+    },
+    {
+      "id": "CWE-326"
+    },
+    { "id": "sonatype-2021-0749" },
+    { "id": "sonatype-2021-0078" }
   ]
 }

--- a/packages/phone-input/src/FlagSelect.tsx
+++ b/packages/phone-input/src/FlagSelect.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@emotion/react';
 import { Icon, getIcon } from '@tablecheck/tablekit-icon';
 import { InputSize } from '@tablecheck/tablekit-input';
 import { Select, createFilter, Config } from '@tablecheck/tablekit-select';
-import { useMemo, ReactNode } from 'react';
+import * as React from 'react';
 
 import { Flag } from './styled/Flag';
 import { getFlagSelectStyles, Label, FlagWrap } from './styles';
@@ -25,24 +25,26 @@ const filterOptions: Config = {
   matchFrom: 'any'
 };
 
-const Opt = ({
+function Opt({
   children = null,
   shortName,
   shouldHideFlags
 }: {
-  children?: ReactNode | null;
+  children?: React.ReactNode | null;
   shortName: string;
   shouldHideFlags: boolean;
-}) => (
-  <Label>
-    {!shouldHideFlags && (
-      <FlagWrap>
-        <Flag country={shortName.toUpperCase()} />
-      </FlagWrap>
-    )}
-    {children}
-  </Label>
-);
+}) {
+  return (
+    <Label>
+      {!shouldHideFlags && (
+        <FlagWrap>
+          <Flag country={shortName.toUpperCase()} />
+        </FlagWrap>
+      )}
+      {children}
+    </Label>
+  );
+}
 
 const getOptionLabel = (opt: I18nCountry) => opt.name || '';
 
@@ -86,7 +88,7 @@ const findCountry = (
   return undefined;
 };
 
-export const FlagSelect = (props: FlagSelectProps): JSX.Element => {
+export function FlagSelect(props: FlagSelectProps): JSX.Element {
   const {
     i18nCountries,
     isInvalid,
@@ -100,7 +102,7 @@ export const FlagSelect = (props: FlagSelectProps): JSX.Element => {
     shouldHideFlags
   } = props;
 
-  const value = useMemo(
+  const value = React.useMemo(
     () => findCountry(countryCode, i18nCountries),
     [countryCode, i18nCountries]
   );
@@ -130,8 +132,7 @@ export const FlagSelect = (props: FlagSelectProps): JSX.Element => {
       options={i18nCountries}
       value={value}
       shouldNotChangeDropdownIcon
-      isRtl={theme.isRtl}
       styles={{ ...getFlagSelectStyles({ theme, size }), ...styles }}
     />
   );
-};
+}

--- a/packages/phone-input/src/styled/PhoneField.ts
+++ b/packages/phone-input/src/styled/PhoneField.ts
@@ -5,7 +5,6 @@ import {
   InputContainer
 } from '@tablecheck/tablekit-input';
 import { BORDER_RADIUS } from '@tablecheck/tablekit-theme';
-import { ifRtl } from '@tablecheck/tablekit-utils';
 
 export const PhoneInputContainer = styled(InputContainer)`
   height: auto;
@@ -20,11 +19,8 @@ export const Wrapper = styled.div`
 export const PhoneInputField = styled(Input)`
   ${({ shouldFitContainer }) => (shouldFitContainer ? 'max-width: 100%' : '')};
   ${InputElement} {
-    border-radius: ${ifRtl(
-      `${BORDER_RADIUS}px 0 0 ${BORDER_RADIUS}px`,
-      `0 ${BORDER_RADIUS}px ${BORDER_RADIUS}px 0`
-    )};
+    border-radius: ${`0 ${BORDER_RADIUS}px ${BORDER_RADIUS}px 0`};
     direction: ltr;
-    text-align: ${ifRtl('right', 'left')};
+    text-align: 'left;
   }
 `;

--- a/packages/phone-input/src/styles.ts
+++ b/packages/phone-input/src/styles.ts
@@ -7,7 +7,7 @@ import {
   Spacing
 } from '@tablecheck/tablekit-theme';
 import { margin, mediaQuery } from '@tablecheck/tablekit-utils';
-import { ReactNode } from 'react';
+import * as React from 'react';
 
 import { FlagSelectProps, SelectType } from './types';
 
@@ -40,20 +40,17 @@ export const getFlagSelectStyles = ({
     minHeight: 'initial',
     transition:
       'background-color 200ms ease-in-out, border-color 200ms ease-in-out, width 100ms',
-    borderRadius: theme.isRtl
-      ? `0 ${BORDER_RADIUS}px ${BORDER_RADIUS}px 0`
-      : `${BORDER_RADIUS}px 0 0 ${BORDER_RADIUS}px`
+    borderRadius: `${BORDER_RADIUS}px 0 0 ${BORDER_RADIUS}px`
   }),
   dropdownIndicator: (style: CSSObject) => ({
     ...style,
     paddingBottom: '0',
     paddingTop: '0',
-    ...(theme.isRtl ? { paddingRight: '0' } : { paddingLeft: '0' })
+    paddingLeft: '0'
   }),
   menu: (style: CSSObject) => ({
     ...style,
-    width: '200px',
-    ...(theme.isRtl && { marginLeft: 'calc(70px - 200px)' })
+    width: '200px'
   }),
   singleValue: (style) => ({
     ...style,
@@ -74,16 +71,10 @@ export const getFlagSelectStyles = ({
     width: undefined
   }),
   groupHeading: (style: CSSObject) => ({
-    ...style,
-    ...(theme.isRtl && { direction: 'rtl' })
+    ...style
   }),
   option: (style: CSSObject) => ({
-    ...style,
-    ...(theme.isRtl && {
-      '&>div': {
-        direction: 'rtl'
-      }
-    })
+    ...style
   })
 });
 
@@ -94,7 +85,7 @@ export const Label = styled.div`
   line-height: 1.2;
 `;
 
-export const FlagWrap = styled.span<{ children: ReactNode | null }>`
+export const FlagWrap = styled.span<{ children: React.ReactNode | null }>`
   margin-top: 1px;
   margin-bottom: 1px;
   ${margin({ right: 8, left: 1 })};


### PR DESCRIPTION
Numbers in arabic are read/written left to right. so we need to keep the orientation of the phone input as is, even when used in an RTL environment

No issue
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-phone-input@3.1.4-canary.167.4370932779.0
  # or 
  yarn add @tablecheck/tablekit-phone-input@3.1.4-canary.167.4370932779.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
