### PR TITLE
fix(tablekit-react-select): apply disabled styles to option

### DIFF
--- a/system/react-select/src/ReactSelect.stories.tsx
+++ b/system/react-select/src/ReactSelect.stories.tsx
@@ -5,7 +5,8 @@ import { useReactSelectConfig } from './index';
 
 const options = ['One', 'Two', 'Three'].map((value) => ({
   label: `Option ${value}`,
-  value
+  value,
+  isDisabled: value === 'Three'
 }));
 
 const contentVariants = [

--- a/system/react-select/src/index.tsx
+++ b/system/react-select/src/index.tsx
@@ -342,7 +342,18 @@ export function useReactSelectConfig<
         ...styles,
         ...menuListStylesObject
       }),
-      option: (styles, { isFocused, isSelected }) => {
+      option: (styles, { isFocused, isSelected, isDisabled }) => {
+        const optionVariables = isDisabled
+          ? {
+              '--option-background-color': 'var(--surface-disabled)',
+              '--option-background-color-hover': 'var(--surface-disabled)',
+              '--option-background-color-active': 'var(--surface-disabled)'
+            }
+          : {
+              '--option-background-color': 'var(--surface)',
+              '--option-background-color-hover': 'var(--surface-hover)',
+              '--option-background-color-active': 'var(--surface-active)'
+            };
         let stateStyles = {};
         if (isSelected) {
           stateStyles = hideSelectedOptions
@@ -355,10 +366,16 @@ export function useReactSelectConfig<
           ...styles,
           ...menuItemStylesObject,
           ...stateStyles,
+          ...optionVariables,
+          background: 'var(--option-background-color)',
           cursor: 'pointer',
-          ':active': isSelected ? {} : menuItemStateStylesObjects.active,
+          ':active': {
+            ...(isSelected ? {} : menuItemStateStylesObjects.active),
+            background: 'var(--option-background-color-active)'
+          },
           ':hover > input[type="checkbox"]': {
-            borderColor: 'var(--text)'
+            borderColor: 'var(--text)',
+            background: 'var(--option-background-color-hover)'
           }
         };
       },


### PR DESCRIPTION
<img width="195" alt="image" src="https://user-images.githubusercontent.com/19342294/224960914-1d4d7fee-40de-46b8-b6dd-5dbf2f9269fe.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.0.1-canary.168.4414311563.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.168.4414311563.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.168.4414311563.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.168.4414311563.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.168.4414311563.0
  # or 
  yarn add @tablecheck/tablekit-css@2.0.1-canary.168.4414311563.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.168.4414311563.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.168.4414311563.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.168.4414311563.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.168.4414311563.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
