### PR TITLE
fix(tablekit-react-select): fix text color for input

### DIFF
--- a/system/react-select/src/index.tsx
+++ b/system/react-select/src/index.tsx
@@ -231,13 +231,12 @@ export function useReactSelectConfig<
         ...styles,
         display: 'grid !important',
         justifyContent: 'stretch',
-        pointerEvents: 'auto',
         height: 'auto',
         width: 'auto',
         minWidth: isCompact ? 'auto' : 180,
         '--is-disabled': isDisabled,
         '--is-rtl': isRtl,
-        'pointer-events': isDisabled ? 'none' : 'auto'
+        pointerEvents: isDisabled ? 'none' : 'auto'
       }),
       control: (styles, { isFocused, isDisabled }) => {
         const isLargeBorder =
@@ -328,7 +327,12 @@ export function useReactSelectConfig<
         gridArea: 'indicators',
         height: INPUT_INTERNAL_HEIGHT
       }),
-      input: (styles) => ({ ...styles, margin: 0, padding: 0 }),
+      input: (styles) => ({
+        ...styles,
+        margin: 0,
+        padding: 0,
+        color: 'var(--text)'
+      }),
       placeholder: (styles) => ({
         ...styles,
         font: 'var(--body-1)',


### PR DESCRIPTION
Issue:

https://user-images.githubusercontent.com/19342294/226863421-0f7cc566-1231-4c01-b669-41628b41b98d.mov


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-css@2.0.1-canary.172.4488609931.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.172.4488609931.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.172.4488609931.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.172.4488609931.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.172.4488609931.0
  # or 
  yarn add @tablecheck/tablekit-css@2.0.1-canary.172.4488609931.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.172.4488609931.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.172.4488609931.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.172.4488609931.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.172.4488609931.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
