### PR TITLE
fix: button styling for stretched state

### DIFF
--- a/system/core/src/components/Button.ts
+++ b/system/core/src/components/Button.ts
@@ -97,10 +97,10 @@ export const variantStyles = {
 
 export const coreStyles = css`
   position: relative;
-  display: grid;
+  display: flex;
+  gap: var(--spacing-l2);
+  justify-content: center;
   padding: 9px var(--spacing-l3);
-  grid-gap: var(--spacing-l2);
-  grid-auto-flow: column;
   white-space: nowrap;
   cursor: pointer;
 


### PR DESCRIPTION
Before:
<img width="1205" alt="Set of buttons; the buttons with icons are misaligned" src="https://user-images.githubusercontent.com/107082171/231672254-21690dab-52cc-4102-88eb-bc4b3f55b990.png">
After:
<img width="1195" alt="Set of buttons; now the buttons with icons are aligned properly" src="https://user-images.githubusercontent.com/107082171/231672360-a2920675-daf0-4a4d-8b6b-ef8411ccac92.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.176.4686200033.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.176.4686200033.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.176.4686200033.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.176.4686200033.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.176.4686200033.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.176.4686200033.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.176.4686200033.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.176.4686200033.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.176.4686200033.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.176.4686200033.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.176.4686200033.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.176.4686200033.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.176.4686200033.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.176.4686200033.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
