### PR TITLE
feat: add vertical multi values variant

### DIFF
--- a/system/react-select/src/index.tsx
+++ b/system/react-select/src/index.tsx
@@ -47,6 +47,7 @@ export interface Options {
   isCompact?: boolean;
   isClearable?: boolean;
   hideSelectedOptions?: boolean;
+  useVerticalMultiValues?: boolean;
   /**
    * This is used for storybook only
    * @deprecated
@@ -94,6 +95,7 @@ export function useReactSelectConfig<
   dataTestId,
   borderSides,
   isMulti,
+  useVerticalMultiValues = false,
   borderRadii = BorderRadii.All,
   icon: unsafeIcon,
   isCompact,
@@ -142,6 +144,21 @@ export function useReactSelectConfig<
           {icon ? <IconWrapper>{icon}</IconWrapper> : null}
           {children}
         </reactSelectComponents.Control>
+      ),
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      ValueContainer: ({ innerProps, children, ...props }) => (
+        <reactSelectComponents.ValueContainer
+          {...props}
+          innerProps={
+            {
+              ...innerProps,
+              id: 'value-container',
+              'data-testid': 'Value Container'
+            } as typeof innerProps
+          }
+        >
+          {children}
+        </reactSelectComponents.ValueContainer>
       ),
       // eslint-disable-next-line @typescript-eslint/naming-convention
       SelectContainer: (props) => {
@@ -247,7 +264,7 @@ export function useReactSelectConfig<
         justifyContent: 'stretch',
         height: 'auto',
         width: 'auto',
-        minWidth: isCompact ? 'auto' : 180,
+        minWidth: isCompact ? '100%' : 180,
         '--is-disabled': isDisabled,
         '--is-rtl': isRtl,
         pointerEvents: isDisabled ? 'none' : 'auto'
@@ -285,10 +302,23 @@ export function useReactSelectConfig<
               '--select-multi-value-hover': 'var(--surface-hover)',
               '--select-multi-value-active': 'var(--surface-active)'
             };
+        let verticalValueContainerStyles = {};
+        if (isMulti && useVerticalMultiValues)
+          verticalValueContainerStyles =
+            isFocused || isInternalFocused
+              ? {
+                  '#value-container > div:last-child': { height: 'auto' }
+                }
+              : {
+                  '#value-container': { marginBottom: -8 },
+                  '#value-container > div:last-child': { height: 0 }
+                };
+
         return {
           ...styles,
           ...borderColorProps,
           ...multiValueVariables,
+          ...verticalValueContainerStyles,
           borderRadius: getBorderRadius(!!theme.isRtl, borderRadii),
           borderWidth: 1,
           padding: `${verticalPadding}px 15px`,
@@ -330,12 +360,20 @@ export function useReactSelectConfig<
                 }
         };
       },
-      valueContainer: (containerStyles) => ({
-        ...containerStyles,
-        padding: 0,
-        gap: 8,
-        gridArea: 'input'
-      }),
+      valueContainer: (containerStyles) => {
+        const verticalStyles: React.CSSProperties =
+          isMulti && useVerticalMultiValues
+            ? { flexDirection: 'column', alignItems: 'flex-start' }
+            : {};
+
+        return {
+          ...containerStyles,
+          ...verticalStyles,
+          padding: 0,
+          gap: 8,
+          gridArea: 'input'
+        };
+      },
       indicatorsContainer: (containerStyles) => ({
         ...containerStyles,
         gridArea: 'indicators',
@@ -446,7 +484,8 @@ export function useReactSelectConfig<
       isMulti,
       borderRadii,
       icon,
-      hideSelectedOptions
+      hideSelectedOptions,
+      useVerticalMultiValues
     ]
   );
   return {

--- a/system/stories/src/ReactSelect.stories.tsx
+++ b/system/stories/src/ReactSelect.stories.tsx
@@ -7,28 +7,38 @@ const options = ['One', 'Two', 'Three'].map((value) => ({
   value
 }));
 
-const contentVariants = [
-  { title: 'Default' },
-  {
-    title: 'With Value',
-    defaultValue: options[0]
-  },
-  { title: 'Focus', isInternalFocused: true },
-  { title: 'Disabled', isDisabled: true },
-  { title: 'Disabled with value', isDisabled: true, defaultValue: options[0] },
-  { title: 'Error', isInvalid: true }
-] as const;
+const getContentVariants = (isMulti = false) => {
+  const defaultValue = isMulti ? [options[0], options[1]] : options[0];
+
+  return [
+    { title: 'Default' },
+    {
+      title: 'With Value',
+      defaultValue
+    },
+    { title: 'Focus', isInternalFocused: true },
+    { title: 'Disabled', isDisabled: true },
+    {
+      title: 'Disabled with value',
+      isDisabled: true,
+      defaultValue
+    },
+    { title: 'Error', isInvalid: true }
+  ] as const;
+};
 
 export default {
   title: 'TableKit/useReactSelect hook',
   parameters: {
-    variants: contentVariants.map(({ title }) => title),
+    variants: getContentVariants().map(({ title }) => title),
     importName: 'useReactSelectConfig',
     packageName: '@tablecheck/tablekit-react-select'
   }
 } as Meta;
 
-const Select = (props: Omit<(typeof contentVariants)[number], 'title'>) => {
+const Select = (
+  props: Omit<ReturnType<typeof getContentVariants>[number], 'title'>
+) => {
   const config = useReactSelectConfig({
     dataTestId: 'test-id',
     ...props
@@ -44,9 +54,11 @@ const Select = (props: Omit<(typeof contentVariants)[number], 'title'>) => {
   );
 };
 
-const MultiSelect = (
-  props: Omit<(typeof contentVariants)[number], 'title'>
-) => {
+const MultiSelect = ({
+  ...props
+}: Omit<ReturnType<typeof getContentVariants>[number], 'title'> & {
+  useVerticalMultiValues?: boolean;
+}) => {
   const config = useReactSelectConfig<{ label: string; value: string }, true>({
     dataTestId: 'test-id',
     isMulti: true,
@@ -66,11 +78,14 @@ const MultiSelect = (
 
 export const Variants: Story = () => (
   <>
-    {contentVariants.map(({ title: key, ...props }) => (
+    {getContentVariants().map(({ title: key, ...props }) => (
       <Select key={key} {...props} />
     ))}
-    {contentVariants.map(({ title: key, ...props }) => (
+    {getContentVariants(true).map(({ title: key, ...props }) => (
       <MultiSelect key={key} {...props} />
+    ))}
+    {getContentVariants(true).map(({ title: key, ...props }) => (
+      <MultiSelect key={key} useVerticalMultiValues {...props} />
     ))}
   </>
 );


### PR DESCRIPTION
Add possibility to display selected values vertically by passing "useVerticalMultiValues" prop.

![image](https://user-images.githubusercontent.com/19342294/232542534-583f7d65-a981-449b-a644-d118078a2592.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.177.4727224744.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.177.4727224744.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.177.4727224744.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.177.4727224744.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.177.4727224744.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.177.4727224744.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.177.4727224744.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.177.4727224744.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.177.4727224744.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.177.4727224744.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.177.4727224744.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.177.4727224744.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.177.4727224744.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.177.4727224744.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
