### PR TITLE
fix: react select styles for non-searchable variant

### DIFF
--- a/system/react-select/src/index.tsx
+++ b/system/react-select/src/index.tsx
@@ -264,7 +264,7 @@ export function useReactSelectConfig<
         justifyContent: 'stretch',
         height: 'auto',
         width: 'auto',
-        minWidth: isCompact ? '100%' : 180,
+        minWidth: isCompact ? 'auto' : 180,
         '--is-disabled': isDisabled,
         '--is-rtl': isRtl,
         pointerEvents: isDisabled ? 'none' : 'auto'
@@ -307,11 +307,13 @@ export function useReactSelectConfig<
           verticalValueContainerStyles =
             isFocused || isInternalFocused
               ? {
-                  '#value-container > div:last-child': { height: 'auto' }
+                  '#value-container > div:last-child, #value-container > input:last-child':
+                    { height: 'auto' }
                 }
               : {
                   '#value-container': { marginBottom: -8 },
-                  '#value-container > div:last-child': { height: 0 }
+                  '#value-container > div:last-child, #value-container > input:last-child':
+                    { height: 0 }
                 };
 
         return {


### PR DESCRIPTION
If select is not searchable input is not wrapped with div tag.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.178.4820996238.0
  # or 
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.178.4820996238.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
