### PR TITLE
fix: MenuItem override styles by classname

### DIFF
--- a/system/core/src/components/MenuItem.ts
+++ b/system/core/src/components/MenuItem.ts
@@ -42,6 +42,7 @@ export const baseStylesObject: CSSObject = {
   gridGap: 'var(--spacing-l2)',
   gridAutoFlow: 'column',
   alignItems: 'center',
+  flex: '1 1 100%',
   justifyContent: 'flex-start',
   textDecoration: 'none !important',
   outline: 'none',

--- a/system/core/src/components/MenuList.ts
+++ b/system/core/src/components/MenuList.ts
@@ -21,10 +21,6 @@ export const baseStylesObject: CSSObject = {
   '& > li': {
     display: 'flex',
     justifyContent: 'stretch'
-  },
-  '& > li > *': {
-    flex: '1 1 100%',
-    justifyContent: 'flex-start'
   }
 };
 


### PR DESCRIPTION
fix for #162 

Removed "'& > li > *': " selector styles from MenuList.ts file and added those styles under baseStyleObject in MenuItem.ts

![image](https://user-images.githubusercontent.com/45478165/235299137-544017c6-df71-455d-892e-ab193db9f721.png)



