### PR TITLE
fix: MenuItem override styles by classname

### DIFF
--- a/system/core/src/components/MenuItem.ts
+++ b/system/core/src/components/MenuItem.ts
@@ -42,6 +42,7 @@ export const baseStylesObject: CSSObject = {
   gridGap: 'var(--spacing-l2)',
   gridAutoFlow: 'column',
   alignItems: 'center',
+  flex: '1 1 100%',
   justifyContent: 'flex-start',
   textDecoration: 'none !important',
   outline: 'none',

--- a/system/core/src/components/MenuList.ts
+++ b/system/core/src/components/MenuList.ts
@@ -21,10 +21,6 @@ export const baseStylesObject: CSSObject = {
   '& > li': {
     display: 'flex',
     justifyContent: 'stretch'
-  },
-  '& > li > *': {
-    flex: '1 1 100%',
-    justifyContent: 'flex-start'
   }
 };
 


### PR DESCRIPTION
fix for #162 

Removed "'& > li > *': " selector styles from MenuList.ts file and added those styles under baseStyleObject in MenuItem.ts

![image](https://user-images.githubusercontent.com/45478165/235299137-544017c6-df71-455d-892e-ab193db9f721.png)

Ported branch to here so we can run chromatic correctly.
Replaces #180 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.182.4988207461.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.182.4988207461.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.182.4988207461.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.182.4988207461.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.182.4988207461.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.182.4988207461.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.182.4988207461.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.182.4988207461.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.182.4988207461.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.182.4988207461.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.182.4988207461.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.182.4988207461.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.182.4988207461.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.182.4988207461.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
