### PR TITLE
fix: standalone spinner styling bugs

### DIFF
--- a/system/core/src/components/Button.ts
+++ b/system/core/src/components/Button.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 
 import {
   beforeStyles as spinnerBeforeStyles,
-  baseStyles as spinnerElementStyles
+  coreStyles as spinnerElementStyles
 } from './Spinner';
 
 export const element = 'button';

--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { variantStyles as buttonVariantStyles } from './Button';
 import {
   beforeStyles as spinnerBeforeStyles,
-  baseStyles as spinnerElementStyles
+  coreStyles as spinnerElementStyles
 } from './Spinner';
 
 export const element = 'button';

--- a/system/core/src/components/Spinner.ts
+++ b/system/core/src/components/Spinner.ts
@@ -21,23 +21,24 @@ to {
 
 const defaultSize = '20px';
 
-export const beforeStyles = css`
-  content: '';
+const positioningStyles = css`
   display: inline-block;
   width: var(--spinner-size, ${defaultSize});
   height: var(--spinner-size, ${defaultSize});
+`;
+
+export const beforeStyles = css`
+  content: '';
+  ${positioningStyles}
   -webkit-mask-image: url('data:image/svg+xml; utf8, <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M17.5 10C17.5 11.4834 17.0601 12.9334 16.236 14.1668C15.4119 15.4001 14.2406 16.3614 12.8701 16.9291C11.4997 17.4968 9.99168 17.6453 8.53682 17.3559C7.08196 17.0665 5.74559 16.3522 4.6967 15.3033C3.64781 14.2544 2.9335 12.918 2.64411 11.4632C2.35472 10.0083 2.50325 8.50032 3.0709 7.12987C3.63856 5.75943 4.59985 4.58809 5.83322 3.76398C7.06659 2.93987 8.51664 2.5 10 2.5V4.375C8.88748 4.375 7.79994 4.7049 6.87492 5.32298C5.94989 5.94107 5.22892 6.81957 4.80318 7.84741C4.37743 8.87524 4.26604 10.0062 4.48308 11.0974C4.70012 12.1885 5.23585 13.1908 6.02252 13.9775C6.80919 14.7641 7.81147 15.2999 8.90262 15.5169C9.99376 15.734 11.1248 15.6226 12.1526 15.1968C13.1804 14.7711 14.0589 14.0501 14.677 13.1251C15.2951 12.2001 15.625 11.1125 15.625 10H17.5Z" fill="currentColor"/></svg>');
   mask-image: url('data:image/svg+xml; utf8, <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M17.5 10C17.5 11.4834 17.0601 12.9334 16.236 14.1668C15.4119 15.4001 14.2406 16.3614 12.8701 16.9291C11.4997 17.4968 9.99168 17.6453 8.53682 17.3559C7.08196 17.0665 5.74559 16.3522 4.6967 15.3033C3.64781 14.2544 2.9335 12.918 2.64411 11.4632C2.35472 10.0083 2.50325 8.50032 3.0709 7.12987C3.63856 5.75943 4.59985 4.58809 5.83322 3.76398C7.06659 2.93987 8.51664 2.5 10 2.5V4.375C8.88748 4.375 7.79994 4.7049 6.87492 5.32298C5.94989 5.94107 5.22892 6.81957 4.80318 7.84741C4.37743 8.87524 4.26604 10.0062 4.48308 11.0974C4.70012 12.1885 5.23585 13.1908 6.02252 13.9775C6.80919 14.7641 7.81147 15.2999 8.90262 15.5169C9.99376 15.734 11.1248 15.6226 12.1526 15.1968C13.1804 14.7711 14.0589 14.0501 14.677 13.1251C15.2951 12.2001 15.625 11.1125 15.625 10H17.5Z" fill="currentColor"/></svg>');
   animation: ${rotateAnimation} 800ms infinite linear;
+  background-color: currentColor;
 `;
 
-export const baseStyles = css`
+export const coreStyles = css`
   cursor: progress;
   pointer-events: none;
-
-  &:before {
-    ${beforeStyles}
-  }
 
   &:not(:empty):before {
     margin-right: var(--spinner-margin, var(--spacing-l1));
@@ -48,5 +49,14 @@ export const baseStyles = css`
 
   &:empty {
     text-align: center;
+  }
+`;
+
+export const baseStyles = css`
+  ${coreStyles}
+  ${positioningStyles}
+
+  &:before {
+    ${beforeStyles}
   }
 `;

--- a/system/stories/src/Spinner.stories.tsx
+++ b/system/stories/src/Spinner.stories.tsx
@@ -1,0 +1,22 @@
+import { Story, Meta } from '@storybook/react';
+import { spinner } from '@tablecheck/tablekit-core';
+import * as emotion from '@tablecheck/tablekit-react';
+import * as css from '@tablecheck/tablekit-react-css';
+
+export default {
+  title: 'TableKit/Spinner',
+  component: emotion.Spinner,
+  parameters: {
+    ...spinner
+  }
+} as Meta;
+
+const Template: Story = ({ Spinner }) => <Spinner aria-busy />;
+
+export const Emotion: Story = Template.bind({});
+Emotion.args = { Spinner: emotion.Spinner };
+Emotion.parameters = { useEmotion: true };
+
+export const Class: Story = Template.bind({});
+Class.args = { Spinner: css.Spinner };
+Class.parameters = { useEmotion: false };


### PR DESCRIPTION
![CleanShot 2023-05-18 at 12 49 10](https://github.com/tablecheck/tablekit/assets/1085899/a0593a01-fb1c-4795-aad4-0e444ead615f)
![CleanShot 2023-05-18 at 12 48 57](https://github.com/tablecheck/tablekit/assets/1085899/e95273d6-c88c-4aaa-8a9a-6e3c4f87d1b9)

Didn't take a screenshot before but basically it was invisible due to no background-color for the mask.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.184.5010581003.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.184.5010581003.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.184.5010581003.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.184.5010581003.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.184.5010581003.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.184.5010581003.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.184.5010581003.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.184.5010581003.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.184.5010581003.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.184.5010581003.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.184.5010581003.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.184.5010581003.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.184.5010581003.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.184.5010581003.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
