### PR TITLE
fix: match types and css data-* selectors

### DIFF
--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -12,7 +12,7 @@ export const className = 'icon-button';
 
 export interface Props {
   'data-variant'?: IconButtonVariant;
-  'data-size'?: 'small' | 'large';
+  'data-size'?: 'small' | 'regular' | 'large';
   'aria-busy'?: boolean;
   'data-round'?: boolean;
   /**

--- a/system/core/src/components/Select.ts
+++ b/system/core/src/components/Select.ts
@@ -43,7 +43,8 @@ export const baseStyles = css`
   );
   cursor: pointer;
   &,
-  &:disabled {
+  &:disabled,
+  &[data-variant='disabled'] {
     background-color: var(--surface);
     background-image: var(--down-chevron-svg);
     background-position: right var(--select-padding-inline) center;
@@ -51,7 +52,8 @@ export const baseStyles = css`
     background-repeat: no-repeat;
     background-size: var(--select-chevron-size) var(--select-chevron-size);
   }
-  &:disabled {
+  &:disabled,
+  &[data-variant='disabled'] {
     background-color: var(--surface-disabled);
     cursor: default;
   }

--- a/system/core/src/components/Toggle.ts
+++ b/system/core/src/components/Toggle.ts
@@ -6,6 +6,7 @@ export const element = 'input';
 export const selectors = ['input[type="checkbox"].toggle'];
 export interface Props {
   type: 'checkbox';
+  'data-size'?: 'small' | 'regular';
 }
 
 export type DefaultedProps = OptionalKeys<Props, 'type'>;


### PR DESCRIPTION
No ticket
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.185.5118342175.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.185.5118342175.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.185.5118342175.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.185.5118342175.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.185.5118342175.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.185.5118342175.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.185.5118342175.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.185.5118342175.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.185.5118342175.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.185.5118342175.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.185.5118342175.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.185.5118342175.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.185.5118342175.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.185.5118342175.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
