### PR TITLE
feat(tablekit-core): change color for error in `InputAlert`, add stories for `InputStructure` and `InputAlert`

### DIFF
--- a/system/core/src/components/InputAlert.ts
+++ b/system/core/src/components/InputAlert.ts
@@ -35,7 +35,7 @@ export const baseStyles = css`
 
   &[data-variant='error'] {
     background: var(--error-surface);
-    color: var(--error);
+    color: var(--error-text);
   }
 
   &[data-variant='warning'] {

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -68,6 +68,7 @@ export type { Props as TooltipProps } from './components/Tooltip';
 export { InputAlertInner, InputAlert } from './structuredComponents/InputAlert';
 export type { Props as InputAlertProps } from './structuredComponents/InputAlert';
 export { InputStructure } from './structuredComponents/InputStructure';
+export type { Props as InputStructureProps } from './structuredComponents/InputStructure';
 export { Skeleton } from './structuredComponents/Skeleton';
 export type { Props as SkeletonProps } from './structuredComponents/Skeleton';
 export { ThemeProvider } from './structuredComponents/ThemeProvider';

--- a/system/react/src/structuredComponents/InputStructure.tsx
+++ b/system/react/src/structuredComponents/InputStructure.tsx
@@ -3,7 +3,7 @@ import { inputStructure } from '@tablecheck/tablekit-core';
 
 import { InputAlert, Props as InputAlertProps } from './InputAlert';
 
-interface Props {
+export interface Props {
   name: string;
   input: React.ReactNode;
   label: React.ReactNode;

--- a/system/stories/src/InputAlert.stories.tsx
+++ b/system/stories/src/InputAlert.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { inputAlert } from '@tablecheck/tablekit-core';
+import * as emotion from '@tablecheck/tablekit-react';
+import * as css from '@tablecheck/tablekit-react-css';
+
+const contentVariants: emotion.InputAlertProps[] = [
+  { id: '1', 'data-variant': 'info', children: 'Info' },
+  { id: '2', 'data-variant': 'warning', children: 'Warning' },
+  { id: '3', 'data-variant': 'error', children: 'Error' }
+];
+
+export default {
+  title: 'TableKit/InputAlert',
+  component: emotion.InputAlert,
+  parameters: {
+    variants: contentVariants.map((props) => props['data-variant']),
+    ...inputAlert
+  }
+} as Meta;
+
+const Template: StoryFn = ({ InputAlert }) => (
+  <>
+    {contentVariants.map(({ id: key, ...props }) => (
+      <InputAlert key={key} {...props} />
+    ))}
+  </>
+);
+
+export const Emotion: StoryFn = Template.bind({});
+Emotion.args = {
+  InputAlert: emotion.InputAlert
+};
+Emotion.parameters = { useEmotion: true };
+
+export const Class: StoryFn = Template.bind({});
+Class.args = {
+  InputAlert: css.InputAlert
+};
+Class.parameters = { useEmotion: false };

--- a/system/stories/src/InputStructure.stories.tsx
+++ b/system/stories/src/InputStructure.stories.tsx
@@ -1,0 +1,96 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { inputStructure } from '@tablecheck/tablekit-core';
+import * as emotion from '@tablecheck/tablekit-react';
+import * as css from '@tablecheck/tablekit-react-css';
+
+const contentVariants: emotion.InputStructureProps[] = [
+  {
+    name: 'input-structure-1',
+    label: 'Default',
+    input: (
+      <emotion.Input
+        name="input-structure-1"
+        title="Default"
+        placeholder="Placeholder"
+      />
+    )
+  },
+  {
+    name: 'input-structure-2',
+    label: 'With Label',
+    input: (
+      <emotion.Input
+        name="input-structure-2"
+        title="Default"
+        placeholder="Placeholder"
+      />
+    ),
+    labelAppend: 'Some Label'
+  },
+  {
+    name: 'input-structure-3',
+    label: 'With Description',
+    input: (
+      <emotion.Input
+        name="input-structure-3"
+        title="Default"
+        placeholder="Placeholder"
+      />
+    ),
+    description: 'Some Descripton'
+  },
+  {
+    name: 'input-structure-4',
+    label: 'With Alert',
+    input: (
+      <emotion.Input
+        name="input-structure-4"
+        title="Default"
+        placeholder="Placeholder"
+      />
+    ),
+    alert: { children: 'Alert', 'data-variant': 'error', id: '1' }
+  },
+  {
+    name: 'input-structure-5',
+    label: 'With All',
+    input: (
+      <emotion.Input
+        name="input-structure-5"
+        title="Default"
+        placeholder="Placeholder"
+      />
+    ),
+    alert: { children: 'Alert', 'data-variant': 'error', id: '1' },
+    description: 'Some Descripton',
+    labelAppend: 'Some Label'
+  }
+];
+
+export default {
+  title: 'TableKit/InputStructure',
+  component: emotion.InputStructure,
+  parameters: {
+    ...inputStructure
+  }
+} as Meta;
+
+const Template: StoryFn = ({ InputStructure }) => (
+  <>
+    {contentVariants.map(({ name: key, ...props }) => (
+      <InputStructure key={key} {...props} />
+    ))}
+  </>
+);
+
+export const Emotion: StoryFn = Template.bind({});
+Emotion.args = {
+  InputStructure: emotion.InputStructure
+};
+Emotion.parameters = { useEmotion: true };
+
+export const Class: StoryFn = Template.bind({});
+Class.args = {
+  InputStructure: css.InputStructure
+};
+Class.parameters = { useEmotion: false };


### PR DESCRIPTION
Ticket: MOPS-1152

# Changes
1. Change `color` of `InputAlert` from `--error` to `--error-text` for better contrast in dark mode
2. Create stories for `InputAlert` and `InputStructure`

# Screenshots
## `InputStructure` story
![image](https://github.com/tablecheck/tablekit/assets/17337106/90247fa0-6501-4635-91b2-a3469c0ab40c)
## `InputAlert` story
![image](https://github.com/tablecheck/tablekit/assets/17337106/070106d7-3704-4b87-aa92-1410c789b31e)


