### PR TITLE
fix(tablekit-core): update warn text for `InputAlert`

### DIFF
--- a/system/core/src/components/InputAlert.ts
+++ b/system/core/src/components/InputAlert.ts
@@ -40,6 +40,6 @@ export const baseStyles = css`
 
   &[data-variant='warning'] {
     background: var(--warning-surface);
-    color: var(--warning);
+    color: var(--warning-text);
   }
 `;


### PR DESCRIPTION
# Changes
1. Set color warning text for `InputAlert` from `--warning` to `--warning-text`

# Screenshot
![image](https://github.com/tablecheck/tablekit/assets/17337106/87d493cc-d99a-4cb8-8162-30a39422abc5)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.187.5285271417.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.187.5285271417.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.187.5285271417.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.187.5285271417.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.187.5285271417.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.187.5285271417.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.187.5285271417.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.187.5285271417.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.187.5285271417.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.187.5285271417.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.187.5285271417.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.187.5285271417.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.187.5285271417.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.187.5285271417.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
