### PR TITLE
fix: correct scoping for allFiles to pass to minifier

### DIFF
--- a/system/css/src/build.ts
+++ b/system/css/src/build.ts
@@ -17,14 +17,6 @@ import { outputFolderPath } from './constants.js';
 
 const cssMinifier = postcss([cssnano({ preset: 'default' })]);
 
-const allFiles: string[] = [];
-async function outputFile(filepath: string, content: string) {
-  if (allFiles.includes(filepath))
-    console.log(`Warning, overwriting ${filepath}`);
-  allFiles.push(filepath);
-  await fs.outputFile(filepath, content);
-}
-
 interface FolderProcessers {
   utils: UtilsFolderProcesser;
   components: ComponentFolderProcesser;
@@ -87,12 +79,19 @@ class CssBuilder {
           [this.allClassyStyles, 'classy']
         ] as const
       ).map(([aggregateStyles, postfix]) =>
-        outputFile(
+        this.outputFile(
           path.join(outputFolderPath, `tablekit.${postfix}.css`),
           aggregateStyles.join('\n')
         )
       )
     );
+  }
+
+  async outputFile(filepath: string, content: string) {
+    if (this.allFiles.includes(filepath))
+      console.log(`Warning, overwriting ${filepath}`);
+    this.allFiles.push(filepath);
+    await fs.outputFile(filepath, content);
   }
 
   async formatOutput() {


### PR DESCRIPTION
The minifier was getting passed an empty array due to there being a `allFiles` global var and a class property. This meant that the build didn't output any minified (`.min.css`) files.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.188.5307140042.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.188.5307140042.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.188.5307140042.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.188.5307140042.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.188.5307140042.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.188.5307140042.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.188.5307140042.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.188.5307140042.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.188.5307140042.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.188.5307140042.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.188.5307140042.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.188.5307140042.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.188.5307140042.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.188.5307140042.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
