### PR TITLE
fix: update alerts

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -988,6 +988,102 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-29827?component-type=npm&component-name=ejs&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/semver@7.3.8",
+      "description": "The semantic version parser used by npm.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/semver@7.3.8?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25883",
+          "title": "[CVE-2022-25883] CWE-1333",
+          "description": "Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25883",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25883?component-type=npm&component-name=semver&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/semver@5.7.1",
+      "description": "The semantic version parser used by npm.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/semver@5.7.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25883",
+          "title": "[CVE-2022-25883] CWE-1333",
+          "description": "Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25883",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25883?component-type=npm&component-name=semver&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/semver@6.3.0",
+      "description": "The semantic version parser used by npm.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/semver@6.3.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25883",
+          "title": "[CVE-2022-25883] CWE-1333",
+          "description": "Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25883",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25883?component-type=npm&component-name=semver&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/tough-cookie@4.1.2",
+      "description": "RFC6265 Cookies and Cookie Jar for node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/tough-cookie@4.1.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-26136",
+          "title": "[CVE-2023-26136] CWE-1321",
+          "description": "Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2023-26136",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-26136?component-type=npm&component-name=tough-cookie&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/tough-cookie@2.5.0",
+      "description": "RFC6265 Cookies and Cookie Jar for node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/tough-cookie@2.5.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-26136",
+          "title": "[CVE-2023-26136] CWE-1321",
+          "description": "Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2023-26136",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-26136?component-type=npm&component-name=tough-cookie&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/semver@7.3.4",
+      "description": "The semantic version parser used by npm.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/semver@7.3.4?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25883",
+          "title": "[CVE-2022-25883] CWE-1333",
+          "description": "Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25883",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25883?component-type=npm&component-name=semver&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1191,6 +1287,12 @@
     },
     {
       "id": "CVE-2023-29827"
+    },
+    {
+      "id": "CVE-2022-25883"
+    },
+    {
+      "id": "CVE-2023-26136"
     }
   ]
 }

--- a/system/core/src/components/Alert.ts
+++ b/system/core/src/components/Alert.ts
@@ -1,0 +1,74 @@
+import { css } from '@emotion/react';
+
+export const element = 'div';
+export const className = 'input-alert';
+
+const variants = ['success', 'info', 'error', 'warning', 'neutral'] as const;
+
+export type AlertVariant = (typeof variants)[number];
+
+export interface Props {
+  /**
+   * This prop should be used with `aria-describedby` on the input field
+   */
+  id: string;
+  'data-variant': AlertVariant;
+  'data-layout':
+    | 'icon-title-close'
+    | 'title-close'
+    | 'title'
+    | 'icon-close'
+    | 'close'
+    | 'text-only';
+}
+
+export const baseStyles = css`
+  display: grid;
+  grid-gap: var(--spacing-l1) var(--spacing-l2);
+  color: var(--neutral-text);
+  background: var(--neutral-surface);
+  border-radius: var(--border-radius-small);
+  padding: var(--spacing-l2) var(--spacing-l3);
+  align-items: flex-start;
+  width: 345px;
+
+  & .input-alert-icon {
+    margin-top: 2px;
+  }
+
+  &[data-layout='icon-title-close'] {
+    grid: 'icon title close' 1fr '. description .' 1fr / min-content 1fr min-content;
+  }
+  &[data-layout='title-close'] {
+    grid: 'title close' 1fr 'description .' 1fr / 1fr min-content;
+  }
+  &[data-layout='title'] {
+    grid: 'title' 1fr 'description' 1fr / 1fr;
+  }
+  &[data-layout='icon-close'] {
+    grid: 'icon description close' 1fr / min-content 1fr min-content;
+  }
+  &[data-layout='close'] {
+    grid: 'description close' 1fr / 1fr min-content;
+  }
+  &[data-layout='text-only'] {
+    grid: 'description' 1fr / 1fr;
+  }
+
+  &[data-variant='error'] {
+    color: var(--error-text);
+    background: var(--error-surface);
+  }
+  &[data-variant='warning'] {
+    color: var(--warning-text);
+    background: var(--warning-surface);
+  }
+  &[data-variant='success'] {
+    color: var(--success-text);
+    background: var(--success-surface);
+  }
+  &[data-variant='info'] {
+    color: var(--info-text);
+    background: var(--info-surface);
+  }
+`;

--- a/system/core/src/components/InputAlert.ts
+++ b/system/core/src/components/InputAlert.ts
@@ -23,6 +23,10 @@ export const baseStyles = css`
   color: var(--text);
   border-radius: var(--border-radius-small);
 
+  & > svg:first-child {
+    margin-top: 2px;
+  }
+
   &[data-variant='error'],
   &[data-variant='warning'] {
     border-radius: var(--border-radius-small);

--- a/system/core/src/index.ts
+++ b/system/core/src/index.ts
@@ -2,6 +2,7 @@
  * DO NOT EDIT: This file is generated, run 'npm update:exports' to update this.
  * The exports here are generated from all ts/tsx files at the root level
  */
+export * as alert from './components/Alert';
 export * as badge from './components/Badge';
 export * as banner from './components/Banner';
 export * as button from './components/Button';

--- a/system/react-css/src/index.ts
+++ b/system/react-css/src/index.ts
@@ -51,6 +51,14 @@ export type { Props as TextAreaProps } from './components/TextArea';
 export { TextAreaWithIcons } from './components/TextAreaWithIcons';
 export type { Props as TextAreaWithIconsProps } from './components/TextAreaWithIcons';
 export {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  AlertCloseButton,
+  AlertIconWrapper
+} from './structuredComponents/Alert';
+export type { Props as AlertProps } from './structuredComponents/Alert';
+export {
   CheckboxLabel,
   RadioLabel
 } from './structuredComponents/CheckboxRadioLabel';

--- a/system/react-css/src/structuredComponents/Alert.tsx
+++ b/system/react-css/src/structuredComponents/Alert.tsx
@@ -1,0 +1,61 @@
+import type { alert } from '@tablecheck/tablekit-core';
+import * as React from 'react';
+
+export type Props = alert.Props;
+
+export const Alert = React.forwardRef<
+  HTMLDivElement,
+  Props & React.HTMLAttributes<HTMLDivElement>
+>((props, ref) => (
+  <div
+    {...props}
+    ref={ref}
+    className={`${props.className || ''} input-alert`}
+  />
+));
+
+export const AlertTitle = React.forwardRef<
+  HTMLHeadingElement,
+  Props & React.HTMLAttributes<HTMLHeadingElement>
+>((props, ref) => (
+  // eslint-disable-next-line jsx-a11y/heading-has-content
+  <h4
+    {...props}
+    ref={ref}
+    style={{ ...(props.style || {}), gridArea: 'title' }}
+  />
+));
+export const AlertDescription = React.forwardRef<
+  HTMLDivElement,
+  Props & React.HTMLAttributes<HTMLDivElement>
+>((props, ref) => (
+  <div
+    {...props}
+    ref={ref}
+    style={{ ...(props.style || {}), gridArea: 'description' }}
+  />
+));
+
+export const AlertCloseButton = React.forwardRef<
+  HTMLButtonElement,
+  Props & React.HTMLAttributes<HTMLButtonElement>
+>((props, ref) => (
+  <button
+    type="button"
+    {...props}
+    ref={ref}
+    style={{ color: 'currentColor', ...(props.style || {}), gridArea: 'close' }}
+  />
+));
+
+export const AlertIconWrapper = React.forwardRef<
+  HTMLSpanElement,
+  Props & React.HTMLAttributes<HTMLSpanElement>
+>((props, ref) => (
+  <span
+    {...props}
+    ref={ref}
+    style={{ ...(props.style || {}), gridArea: 'icon' }}
+    className={`${props.className || ''} input-alert-icon`}
+  />
+));

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -65,6 +65,14 @@ export { Toggle } from './components/Toggle';
 export type { Props as ToggleProps } from './components/Toggle';
 export { Tooltip } from './components/Tooltip';
 export type { Props as TooltipProps } from './components/Tooltip';
+export {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+  AlertCloseButton,
+  AlertIconWrapper
+} from './structuredComponents/Alert';
+export type { Props as AlertProps } from './structuredComponents/Alert';
 export { InputAlertInner, InputAlert } from './structuredComponents/InputAlert';
 export type { Props as InputAlertProps } from './structuredComponents/InputAlert';
 export { InputStructure } from './structuredComponents/InputStructure';

--- a/system/react/src/structuredComponents/Alert.tsx
+++ b/system/react/src/structuredComponents/Alert.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+import { alert } from '@tablecheck/tablekit-core';
+import * as React from 'react';
+
+export type Props = alert.Props;
+
+export const Alert = styled.div<Props>`
+  ${alert.baseStyles}
+`;
+
+export const AlertTitle = styled.h4`
+  grid-area: title;
+`;
+
+export const AlertDescription = styled.div`
+  grid-area: description;
+`;
+
+export const AlertCloseButton = styled.button`
+  grid-area: close;
+  color: currentColor;
+`;
+
+export const AlertIconWrapper = React.forwardRef<
+  HTMLSpanElement,
+  Props & React.HTMLAttributes<HTMLSpanElement>
+>((props, ref) => (
+  <span
+    {...props}
+    ref={ref}
+    style={{ ...(props.style || {}), gridArea: 'icon' }}
+    className={`${props.className || ''} input-alert-icon`}
+  />
+));

--- a/system/stories/src/Alert.stories.tsx
+++ b/system/stories/src/Alert.stories.tsx
@@ -1,0 +1,175 @@
+import {
+  CarbonIcon,
+  CheckmarkFilled,
+  Close,
+  Information,
+  WarningAlt,
+  WarningAltFilled
+} from '@carbon/icons-react';
+import { Meta, StoryFn } from '@storybook/react';
+import { alert } from '@tablecheck/tablekit-core';
+import * as emotion from '@tablecheck/tablekit-react';
+import * as css from '@tablecheck/tablekit-react-css';
+import * as React from 'react';
+
+const contentVariants: emotion.AlertProps['data-variant'][] = [
+  'success',
+  'info',
+  'error',
+  'warning',
+  'neutral'
+];
+
+const CloseIcon = () => <Close size={20} />;
+
+type LayoutComponents = Record<
+  'Title' | 'Description' | 'CloseButton' | 'IconWrapper',
+  React.ElementType
+>;
+
+const layouts: {
+  key: emotion.AlertProps['data-layout'];
+  render: (
+    layoutComponents: LayoutComponents,
+    icon: CarbonIcon
+  ) => React.ReactNode;
+}[] = [
+  {
+    key: 'icon-title-close',
+    render: (
+      { CloseButton, Description, IconWrapper, Title },
+      InstanceIcon
+    ) => (
+      <>
+        <IconWrapper>
+          <InstanceIcon size={20} />
+        </IconWrapper>
+        <Title>Title</Title>
+        <Description>More text here</Description>
+        <CloseButton>
+          <CloseIcon />
+        </CloseButton>
+      </>
+    )
+  },
+  {
+    key: 'title-close',
+    render: ({ CloseButton, Description, Title }) => (
+      <>
+        <Title>Title</Title>
+        <Description>More text here</Description>
+        <CloseButton>
+          <CloseIcon />
+        </CloseButton>
+      </>
+    )
+  },
+  {
+    key: 'title',
+    render: ({ Description, Title }) => (
+      <>
+        <Title>Title</Title>
+        <Description>More text here</Description>
+      </>
+    )
+  },
+  {
+    key: 'icon-close',
+    render: ({ CloseButton, Description, IconWrapper }, InstanceIcon) => (
+      <>
+        <IconWrapper>
+          <InstanceIcon size={16} />
+        </IconWrapper>
+        <Description>More text here</Description>
+        <CloseButton>
+          <CloseIcon />
+        </CloseButton>
+      </>
+    )
+  },
+  {
+    key: 'close',
+    render: ({ CloseButton, Description }) => (
+      <>
+        <Description>More text here</Description>
+        <CloseButton>
+          <CloseIcon />
+        </CloseButton>
+      </>
+    )
+  },
+  {
+    key: 'text-only',
+    render: ({ Description }) => <Description>More text here</Description>
+  }
+];
+
+// eslint-disable-next-line consistent-return
+function getIcon(variant: (typeof contentVariants)[number]) {
+  switch (variant) {
+    case 'success':
+      return CheckmarkFilled;
+    case 'error':
+      return WarningAltFilled;
+    case 'neutral':
+    case 'info':
+      return Information;
+    case 'warning':
+      return WarningAlt;
+  }
+}
+
+export default {
+  title: 'TableKit/Alert',
+  component: emotion.Alert,
+  parameters: {
+    ...alert,
+    variants: contentVariants,
+    auxiliaryClassNames: ['input-alert-icon'],
+    auxiliaryComponents: [
+      emotion.AlertTitle,
+      emotion.AlertDescription,
+      emotion.AlertCloseButton,
+      emotion.AlertIconWrapper
+    ]
+  }
+} as Meta;
+
+const Template: StoryFn = ({ Alert, ...layoutComponents }) => (
+  <>
+    {layouts.map((layout) =>
+      contentVariants.map((variant) => (
+        <Alert
+          key={`${variant}-${layout}`}
+          data-variant={variant}
+          data-layout={layout.key}
+        >
+          {layout.render(
+            layoutComponents as LayoutComponents,
+            getIcon(variant)
+          )}
+        </Alert>
+      ))
+    )}
+  </>
+);
+
+export const Emotion: StoryFn = Template.bind({});
+Emotion.args = {
+  Alert: emotion.Alert,
+  Title: emotion.AlertTitle,
+  Description: emotion.AlertDescription,
+  CloseButton: emotion.AlertCloseButton,
+  IconWrapper: emotion.AlertIconWrapper
+} satisfies LayoutComponents & { Alert: React.ElementType };
+Emotion.parameters = { useEmotion: true };
+
+export const Class: StoryFn = Template.bind({});
+Class.args = {
+  Alert: css.Alert,
+  Title: css.AlertTitle,
+  Description: css.AlertDescription,
+  CloseButton: css.AlertCloseButton,
+  IconWrapper: css.AlertIconWrapper
+} satisfies LayoutComponents & { Alert: React.ElementType };
+Class.parameters = { useEmotion: false };

--- a/system/stories/src/Menu.stories.tsx
+++ b/system/stories/src/Menu.stories.tsx
@@ -11,7 +11,7 @@ export default {
   parameters: {
     ...menu,
     auxiliaryClassNames: [menuItem.className, menuList.className],
-    auxiliarySelectors: [undefined, menuList.selectors],
+    auxiliarySelectors: [`.${menuItem.className}`, menuList.selectors],
     auxiliaryComponents: [emotion.MenuItem, emotion.MenuList]
   }
 } as Meta;


### PR DESCRIPTION
Add base alert and fix input alert

close #108

![CleanShot 2023-07-10 at 19 34 24](https://github.com/tablecheck/tablekit/assets/1085899/8575b6e4-857c-43e0-91ca-73548b32374a)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.1.0-canary.189.5516015831.0
  npm install @tablecheck/tablekit-css@2.1.0-canary.189.5516015831.0
  npm install @tablecheck/tablekit-react-css@2.1.0-canary.189.5516015831.0
  npm install @tablecheck/tablekit-react-datepicker@2.1.0-canary.189.5516015831.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.189.5516015831.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.189.5516015831.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.189.5516015831.0
  # or 
  yarn add @tablecheck/tablekit-core@2.1.0-canary.189.5516015831.0
  yarn add @tablecheck/tablekit-css@2.1.0-canary.189.5516015831.0
  yarn add @tablecheck/tablekit-react-css@2.1.0-canary.189.5516015831.0
  yarn add @tablecheck/tablekit-react-datepicker@2.1.0-canary.189.5516015831.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.189.5516015831.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.189.5516015831.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.189.5516015831.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
