### PR TITLE
fix: add missing alert layouts and remove irrelevant type

### DIFF
--- a/system/core/src/components/Alert.ts
+++ b/system/core/src/components/Alert.ts
@@ -1,24 +1,22 @@
 import { css } from '@emotion/react';
 
 export const element = 'div';
-export const className = 'input-alert';
+export const className = 'alert';
 
 const variants = ['success', 'info', 'error', 'warning', 'neutral'] as const;
 
 export type AlertVariant = (typeof variants)[number];
 
 export interface Props {
-  /**
-   * This prop should be used with `aria-describedby` on the input field
-   */
-  id: string;
   'data-variant': AlertVariant;
   'data-layout':
     | 'icon-title-close'
     | 'title-close'
+    | 'icon-title'
     | 'title'
     | 'icon-close'
     | 'close'
+    | 'icon'
     | 'text-only';
 }
 
@@ -32,12 +30,15 @@ export const baseStyles = css`
   align-items: flex-start;
   width: 345px;
 
-  & .input-alert-icon {
+  & .alert-icon {
     margin-top: 2px;
   }
 
   &[data-layout='icon-title-close'] {
     grid: 'icon title close' 1fr '. description .' 1fr / min-content 1fr min-content;
+  }
+  &[data-layout='icon-title'] {
+    grid: 'icon title' 1fr '. description' 1fr / min-content 1fr min-content;
   }
   &[data-layout='title-close'] {
     grid: 'title close' 1fr 'description .' 1fr / 1fr min-content;
@@ -47,6 +48,9 @@ export const baseStyles = css`
   }
   &[data-layout='icon-close'] {
     grid: 'icon description close' 1fr / min-content 1fr min-content;
+  }
+  &[data-layout='icon'] {
+    grid: 'icon description' 1fr / min-content 1fr min-content;
   }
   &[data-layout='close'] {
     grid: 'description close' 1fr / 1fr min-content;

--- a/system/react-css/src/structuredComponents/Alert.tsx
+++ b/system/react-css/src/structuredComponents/Alert.tsx
@@ -7,16 +7,12 @@ export const Alert = React.forwardRef<
   HTMLDivElement,
   Props & React.HTMLAttributes<HTMLDivElement>
 >((props, ref) => (
-  <div
-    {...props}
-    ref={ref}
-    className={`${props.className || ''} input-alert`}
-  />
+  <div {...props} ref={ref} className={`${props.className || ''} alert`} />
 ));
 
 export const AlertTitle = React.forwardRef<
   HTMLHeadingElement,
-  Props & React.HTMLAttributes<HTMLHeadingElement>
+  React.HTMLAttributes<HTMLHeadingElement>
 >((props, ref) => (
   // eslint-disable-next-line jsx-a11y/heading-has-content
   <h4
@@ -27,7 +23,7 @@ export const AlertTitle = React.forwardRef<
 ));
 export const AlertDescription = React.forwardRef<
   HTMLDivElement,
-  Props & React.HTMLAttributes<HTMLDivElement>
+  React.HTMLAttributes<HTMLDivElement>
 >((props, ref) => (
   <div
     {...props}
@@ -38,19 +34,24 @@ export const AlertDescription = React.forwardRef<
 
 export const AlertCloseButton = React.forwardRef<
   HTMLButtonElement,
-  Props & React.HTMLAttributes<HTMLButtonElement>
+  React.HTMLAttributes<HTMLButtonElement>
 >((props, ref) => (
   <button
     type="button"
     {...props}
     ref={ref}
-    style={{ color: 'currentColor', ...(props.style || {}), gridArea: 'close' }}
+    style={{
+      cursor: 'pointer',
+      color: 'currentColor',
+      ...(props.style || {}),
+      gridArea: 'close'
+    }}
   />
 ));
 
 export const AlertIconWrapper = React.forwardRef<
   HTMLSpanElement,
-  Props & React.HTMLAttributes<HTMLSpanElement>
+  React.HTMLAttributes<HTMLSpanElement>
 >((props, ref) => (
   <span
     {...props}

--- a/system/react/src/structuredComponents/Alert.tsx
+++ b/system/react/src/structuredComponents/Alert.tsx
@@ -19,16 +19,17 @@ export const AlertDescription = styled.div`
 export const AlertCloseButton = styled.button`
   grid-area: close;
   color: currentColor;
+  cursor: pointer;
 `;
 
 export const AlertIconWrapper = React.forwardRef<
   HTMLSpanElement,
-  Props & React.HTMLAttributes<HTMLSpanElement>
+  React.HTMLAttributes<HTMLSpanElement>
 >((props, ref) => (
   <span
     {...props}
     ref={ref}
     style={{ ...(props.style || {}), gridArea: 'icon' }}
-    className={`${props.className || ''} input-alert-icon`}
+    className={`${props.className || ''} alert-icon`}
   />
 ));

--- a/system/stories/.storybook/preview.tsx
+++ b/system/stories/.storybook/preview.tsx
@@ -249,7 +249,7 @@ class StoryParametersParser {
     const { importName, auxiliaryComponents } = this.parameters;
     const componentDisplayName = importName || this.component?.displayName;
     const auxiliaryComponentNames = (auxiliaryComponents || []).map(
-      (c) => c.displayName || c.name || c.__docgenInfo?.displayName
+      (c) => c.displayName || c.__docgenInfo?.displayName
     );
 
     return [componentDisplayName]

--- a/system/stories/src/Alert.stories.tsx
+++ b/system/stories/src/Alert.stories.tsx
@@ -65,6 +65,18 @@ const layouts: {
     )
   },
   {
+    key: 'icon-title',
+    render: ({ Description, IconWrapper, Title }, InstanceIcon) => (
+      <>
+        <IconWrapper>
+          <InstanceIcon size={20} />
+        </IconWrapper>
+        <Title>Title</Title>
+        <Description>More text here</Description>
+      </>
+    )
+  },
+  {
     key: 'title',
     render: ({ Description, Title }) => (
       <>
@@ -99,6 +111,17 @@ const layouts: {
     )
   },
   {
+    key: 'icon',
+    render: ({ Description, IconWrapper }, InstanceIcon) => (
+      <>
+        <IconWrapper>
+          <InstanceIcon size={16} />
+        </IconWrapper>
+        <Description>More text here</Description>
+      </>
+    )
+  },
+  {
     key: 'text-only',
     render: ({ Description }) => <Description>More text here</Description>
   }
@@ -125,7 +148,7 @@ export default {
   parameters: {
     ...alert,
     variants: contentVariants,
-    auxiliaryClassNames: ['input-alert-icon'],
+    auxiliaryClassNames: ['alert-icon'],
     auxiliaryComponents: [
       emotion.AlertTitle,
       emotion.AlertDescription,


### PR DESCRIPTION
No ticket
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.190.5528090547.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.190.5528090547.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.190.5528090547.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.190.5528090547.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.190.5528090547.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.190.5528090547.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.190.5528090547.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.190.5528090547.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.190.5528090547.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.190.5528090547.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.190.5528090547.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.190.5528090547.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.190.5528090547.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.190.5528090547.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
