### PR TITLE
fix: remove medium font-weight references

### DIFF
--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -55,7 +55,6 @@ export const coreStyles = css`
   padding: calc(var(--padding) - 3px);
   cursor: pointer;
 
-  font-weight: 500;
   font-size: 16px;
   line-height: 24px;
   border-radius: var(--border-radius-small);

--- a/system/core/src/components/TabButton.ts
+++ b/system/core/src/components/TabButton.ts
@@ -24,7 +24,7 @@ export const baseStyles = css`
   position: relative;
   text-decoration: none !important;
   color: var(--text);
-  font-weight: 500;
+  font-weight: 400;
   cursor: pointer;
   --underline-height: 4px;
   &:after {
@@ -56,8 +56,11 @@ export const baseStyles = css`
       transform: scale(0.97);
     }
   }
-  &[aria-selected='true']:after {
-    opacity: 1;
-    transform: scale(1);
+  &[aria-selected='true'] {
+    font-weight: 600;
+    &:after {
+      opacity: 1;
+      transform: scale(1);
+    }
   }
 `;


### PR DESCRIPTION
closes #193
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.194.5528401108.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.194.5528401108.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.194.5528401108.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.194.5528401108.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.194.5528401108.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.194.5528401108.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.194.5528401108.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.194.5528401108.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.194.5528401108.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.194.5528401108.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.194.5528401108.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.194.5528401108.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.194.5528401108.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.194.5528401108.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
