### PR TITLE
feat(tablekit-core): add `data-variant` as prop for `MenuItem`

### DIFF
--- a/system/core/src/components/MenuItem.ts
+++ b/system/core/src/components/MenuItem.ts
@@ -2,6 +2,7 @@ import { css, CSSObject } from '@emotion/react';
 
 export const element = 'button';
 export const className = 'menu-item';
+const variants = ['success', 'info', 'error', 'warning'] as const;
 
 /**
  * We export the objects as well for compatibilty with 3rd party libs like react-select
@@ -28,7 +29,6 @@ export const stateStylesObjects: Record<
     background: 'var(--surface-active)'
   },
   hover: {
-    color: 'var(--text)',
     background: 'var(--surface-hover)'
   }
 };
@@ -48,11 +48,24 @@ export const baseStylesObject: CSSObject = {
   outline: 'none',
   '&:is(button, :any-link)': {
     cursor: 'pointer'
+  },
+  '&[data-variant="success"]': {
+    color: 'var(--success)'
+  },
+  '&[data-variant="info"]': {
+    color: 'var(--info)'
+  },
+  '&[data-variant="error"]': {
+    color: 'var(--error)'
+  },
+  '&[data-variant="warning"]': {
+    color: 'var(--warning)'
   }
 };
 
 export interface Props {
   'data-selected'?: boolean;
+  'data-variant'?: (typeof variants)[number];
 }
 
 // eslint-disable-next-line @emotion/syntax-preference

--- a/system/stories/src/Menu.stories.tsx
+++ b/system/stories/src/Menu.stories.tsx
@@ -1,6 +1,6 @@
 import { Earth } from '@carbon/icons-react';
 import { action } from '@storybook/addon-actions';
-import { Story, Meta } from '@storybook/react';
+import { Meta, StoryFn } from '@storybook/react';
 import { menu, menuItem, menuList } from '@tablecheck/tablekit-core';
 import * as emotion from '@tablecheck/tablekit-react';
 import * as css from '@tablecheck/tablekit-react-css';
@@ -16,7 +16,7 @@ export default {
   }
 } as Meta;
 
-const Template: Story = ({ components }) => (
+const Template: StoryFn = ({ components }) => (
   <components.Menu>
     <components.MenuList>
       <li>
@@ -47,19 +47,34 @@ const Template: Story = ({ components }) => (
         </components.MenuItem>
       </li>
       <li>
-        <components.MenuItem>Item</components.MenuItem>
+        <components.MenuItem data-variant="success">
+          <Earth size={20} />
+          Success
+        </components.MenuItem>
       </li>
       <li>
-        <components.MenuItem>Item</components.MenuItem>
+        <components.MenuItem data-variant="info">
+          <Earth size={20} />
+          Info
+        </components.MenuItem>
       </li>
       <li>
-        <components.MenuItem>Item</components.MenuItem>
+        <components.MenuItem data-variant="error">
+          <Earth size={20} />
+          Error
+        </components.MenuItem>
+      </li>
+      <li>
+        <components.MenuItem data-variant="warning">
+          <Earth size={20} />
+          Warn
+        </components.MenuItem>
       </li>
     </components.MenuList>
   </components.Menu>
 );
 
-export const Emotion: Story = Template.bind({});
+export const Emotion: StoryFn = Template.bind({});
 Emotion.args = {
   components: {
     Menu: emotion.Menu,
@@ -70,7 +85,7 @@ Emotion.args = {
 };
 Emotion.parameters = { useEmotion: true };
 
-export const Class: Story = Template.bind({});
+export const Class: StoryFn = Template.bind({});
 Class.args = {
   components: {
     Menu: css.Menu,


### PR DESCRIPTION
## Changes
* Added `data-variant` prop to `MenuItem`

## Screenshot
<img width="1468" alt="Screenshot 2023-08-03 at 19 12 12" src="https://github.com/tablecheck/tablekit/assets/17337106/9e8cbd46-6af0-4d9c-bb1d-c8878178957e">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.1.0-canary.196.5758751898.0
  npm install @tablecheck/tablekit-css@2.1.0-canary.196.5758751898.0
  npm install @tablecheck/tablekit-react-css@2.1.0-canary.196.5758751898.0
  npm install @tablecheck/tablekit-react-datepicker@2.1.0-canary.196.5758751898.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.196.5758751898.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.196.5758751898.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.196.5758751898.0
  # or 
  yarn add @tablecheck/tablekit-core@2.1.0-canary.196.5758751898.0
  yarn add @tablecheck/tablekit-css@2.1.0-canary.196.5758751898.0
  yarn add @tablecheck/tablekit-react-css@2.1.0-canary.196.5758751898.0
  yarn add @tablecheck/tablekit-react-datepicker@2.1.0-canary.196.5758751898.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.196.5758751898.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.196.5758751898.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.196.5758751898.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
