### PR TITLE
fix: make button and icon button consistently sized

### DIFF
--- a/system/core/src/components/Button.ts
+++ b/system/core/src/components/Button.ts
@@ -15,7 +15,7 @@ export interface Props {
    */
   'data-tooltip'?: never;
   'data-variant'?: ButtonVariant;
-  'data-size'?: 'small' | 'large';
+  'data-size'?: 'small' | 'medium' | 'large';
   'aria-busy'?: boolean;
 }
 
@@ -100,7 +100,7 @@ export const coreStyles = css`
   display: flex;
   gap: var(--spacing-l2);
   justify-content: center;
-  padding: 9px var(--spacing-l3);
+  padding: 9px 11px;
   white-space: nowrap;
   cursor: pointer;
 
@@ -176,13 +176,13 @@ export const coreStyles = css`
   }
 
   &[data-size='small'] {
-    padding: 7px var(--spacing-l2);
+    padding: 7px;
     font-size: 14px;
     line-height: 16px;
   }
 
   &[data-size='large'] {
-    padding: 13px var(--spacing-l4);
+    padding: 13px 15px;
     font-size: 16px;
     line-height: 20px;
   }

--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -12,7 +12,7 @@ export const className = 'icon-button';
 
 export interface Props {
   'data-variant'?: IconButtonVariant;
-  'data-size'?: 'small' | 'regular' | 'large';
+  'data-size'?: 'small' | 'medium' | 'large';
   'aria-busy'?: boolean;
   'data-round'?: boolean;
   /**
@@ -49,10 +49,9 @@ export const variantStyles = {
 };
 
 export const coreStyles = css`
-  --padding: 12px;
   position: relative;
   display: grid;
-  padding: calc(var(--padding) - 3px);
+  padding: 9px;
   cursor: pointer;
 
   font-size: 16px;
@@ -142,11 +141,11 @@ export const coreStyles = css`
   }
 
   &[data-size='small'] {
-    padding: calc(var(--padding) - 5px);
+    padding: 7px;
   }
 
   &[data-size='large'] {
-    padding: calc(var(--padding) + 1px);
+    padding: 13px;
   }
 `;
 


### PR DESCRIPTION
Found this inconsistency when putting two buttons next to each other. Padding are "magical numbers" because of 1px border width.

![CleanShot 2023-08-14 at 18 36 19](https://github.com/tablecheck/tablekit/assets/1085899/830c0c13-d9c9-46f2-b135-63ed35782df9)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.197.5854331170.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.197.5854331170.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.197.5854331170.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.197.5854331170.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.197.5854331170.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.197.5854331170.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.197.5854331170.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.197.5854331170.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.197.5854331170.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.197.5854331170.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.197.5854331170.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.197.5854331170.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.197.5854331170.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.197.5854331170.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
