### PR TITLE
fix: add wrap option to tabs and reduce gap to 8px

### DIFF
--- a/system/core/src/components/Tabs.ts
+++ b/system/core/src/components/Tabs.ts
@@ -5,6 +5,7 @@ import { OptionalKeys } from '../typeUtils';
 export const className = 'tabs';
 export interface Props {
   role: 'tablist';
+  'data-wrap'?: boolean;
 }
 
 export type DefaultedProps = OptionalKeys<Props, 'role'>;
@@ -13,5 +14,8 @@ export const defaultProps = { role: 'tablist' };
 export const baseStyles = css`
   display: flex;
   flex-direction: row;
-  gap: var(--spacing-l5);
+  gap: var(--spacing-l2);
+  &[data-wrap='true'] {
+    flex-wrap: wrap;
+  }
 `;


### PR DESCRIPTION
No ticket
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.198.5874799501.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.198.5874799501.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.198.5874799501.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.198.5874799501.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.198.5874799501.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.198.5874799501.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.198.5874799501.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.198.5874799501.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.198.5874799501.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.198.5874799501.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.198.5874799501.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.198.5874799501.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.198.5874799501.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.198.5874799501.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
