### PR TITLE
feat: add default anchor styling

### DIFF
--- a/system/core/src/components/MenuItem.ts
+++ b/system/core/src/components/MenuItem.ts
@@ -71,6 +71,7 @@ export interface Props {
 // eslint-disable-next-line @emotion/syntax-preference
 export const baseStyles = css({
   ...baseStylesObject,
+  '&:is(button, :any-link)': baseStylesObject,
   '&:is(button, :any-link):active': stateStylesObjects.active,
   '&:is(button, :any-link)[data-pseudo="active"]': stateStylesObjects.active,
   '&:is(button, :any-link):focus': stateStylesObjects.focus,

--- a/system/core/src/utils/resetCss.ts
+++ b/system/core/src/utils/resetCss.ts
@@ -76,4 +76,17 @@ export const resetCss = css`
   button {
     background-color: transparent;
   }
+  a {
+    color: var(--link-disabled);
+    &:link {
+      color: var(--link);
+    }
+    &:hover,
+    &:active {
+      color: var(--link-hover);
+    }
+    &:visited {
+      color: var(--link-visited);
+    }
+  }
 `;

--- a/system/stories/src/Menu.stories.tsx
+++ b/system/stories/src/Menu.stories.tsx
@@ -12,13 +12,14 @@ export default {
     ...menu,
     auxiliaryClassNames: [menuItem.className, menuList.className],
     auxiliarySelectors: [`.${menuItem.className}`, menuList.selectors],
-    auxiliaryComponents: [emotion.MenuItem, emotion.MenuList]
+    auxiliaryComponents: [emotion.MenuItem, emotion.MenuList],
+    variants: ['Menu', 'Menu Items']
   }
 } as Meta;
 
-const Template: StoryFn = ({ components }) => (
-  <components.Menu>
-    <components.MenuList>
+function AllMenuItems({ components }: any) {
+  return (
+    <>
       <li>
         <components.MenuItem>Item</components.MenuItem>
       </li>
@@ -70,8 +71,21 @@ const Template: StoryFn = ({ components }) => (
           Warn
         </components.MenuItem>
       </li>
+    </>
+  );
+}
+
+const Template: StoryFn = ({ components }) => (
+  <>
+    <components.Menu>
+      <components.MenuList>
+        <AllMenuItems components={components} />
+      </components.MenuList>
+    </components.Menu>
+    <components.MenuList style={{ maxHeight: 'none' }}>
+      <AllMenuItems components={components} />
     </components.MenuList>
-  </components.Menu>
+  </>
 );
 
 export const Emotion: StoryFn = Template.bind({});


### PR DESCRIPTION
Closes #141
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.1.0-canary.201.5888231482.0
  npm install @tablecheck/tablekit-css@2.1.0-canary.201.5888231482.0
  npm install @tablecheck/tablekit-react-css@2.1.0-canary.201.5888231482.0
  npm install @tablecheck/tablekit-react-datepicker@2.1.0-canary.201.5888231482.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.201.5888231482.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.201.5888231482.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.201.5888231482.0
  # or 
  yarn add @tablecheck/tablekit-core@2.1.0-canary.201.5888231482.0
  yarn add @tablecheck/tablekit-css@2.1.0-canary.201.5888231482.0
  yarn add @tablecheck/tablekit-react-css@2.1.0-canary.201.5888231482.0
  yarn add @tablecheck/tablekit-react-datepicker@2.1.0-canary.201.5888231482.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.201.5888231482.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.201.5888231482.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.201.5888231482.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
