### PR TITLE
fix: link hover/active/visited only apply when link

### DIFF
--- a/system/core/src/components/Button.ts
+++ b/system/core/src/components/Button.ts
@@ -143,7 +143,11 @@ export const coreStyles = css`
     }
   }
 
-  color: var(--color);
+  &,
+  &:any-link,
+  &:hover {
+    color: var(--color);
+  }
   background-color: var(--background-color);
   border-color: var(--border-color);
   --loading-transition: 300ms ease-in-out;

--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -97,7 +97,11 @@ export const coreStyles = css`
     }
   }
 
-  color: var(--color);
+  &,
+  &:any-link,
+  &:hover {
+    color: var(--color);
+  }
   background-color: var(--background-color);
   --loading-transition: 300ms ease-in-out;
   transition: color var(--loading-transition),

--- a/system/core/src/components/MenuItem.ts
+++ b/system/core/src/components/MenuItem.ts
@@ -35,7 +35,9 @@ export const stateStylesObjects: Record<
 
 export const baseStylesObject: CSSObject = {
   font: 'var(--body-1)',
-  color: 'var(--text)',
+  '&, &:any-link, &:hover': {
+    color: 'var(--text)'
+  },
   padding: 'var(--spacing-l3)',
   borderRadius: 'var(--border-radius-small)',
   display: 'grid',
@@ -46,7 +48,7 @@ export const baseStylesObject: CSSObject = {
   justifyContent: 'flex-start',
   textDecoration: 'none !important',
   outline: 'none',
-  '&:is(button, :any-link)': {
+  '&:is(button, :any-link), &:matches(button, :any-link)': {
     cursor: 'pointer'
   },
   '&[data-variant="success"]': {
@@ -71,12 +73,17 @@ export interface Props {
 // eslint-disable-next-line @emotion/syntax-preference
 export const baseStyles = css({
   ...baseStylesObject,
-  '&:is(button, :any-link)': baseStylesObject,
-  '&:is(button, :any-link):active': stateStylesObjects.active,
-  '&:is(button, :any-link)[data-pseudo="active"]': stateStylesObjects.active,
-  '&:is(button, :any-link):focus': stateStylesObjects.focus,
-  '&:is(button, :any-link)[data-pseudo="focus"]': stateStylesObjects.focus,
-  '&:is(button, :any-link):hover': stateStylesObjects.hover,
-  '&:is(button, :any-link)[data-pseudo="hover"]': stateStylesObjects.hover,
+  '&:matches(button, :any-link):matches(:active, [data-pseudo="active"])':
+    stateStylesObjects.active,
+  '&:is(button, :any-link):is(:active, [data-pseudo="active"])':
+    stateStylesObjects.active,
+  '&:matches(button, :any-link):matches(:focus, [data-pseudo="focus"])':
+    stateStylesObjects.focus,
+  '&:is(button, :any-link):is(:focus, [data-pseudo="focus"])':
+    stateStylesObjects.focus,
+  '&:matches(button, :any-link):matches(:hover, [data-pseudo="hover"])':
+    stateStylesObjects.hover,
+  '&:is(button, :any-link):is(:hover, [data-pseudo="hover"])':
+    stateStylesObjects.hover,
   '&[data-selected=true]': stateStylesObjects.selected
 });

--- a/system/core/src/utils/resetCss.ts
+++ b/system/core/src/utils/resetCss.ts
@@ -80,13 +80,13 @@ export const resetCss = css`
     color: var(--link-disabled);
     &:link {
       color: var(--link);
-    }
-    &:hover,
-    &:active {
-      color: var(--link-hover);
-    }
-    &:visited {
-      color: var(--link-visited);
+      &:hover,
+      &:active {
+        color: var(--link-hover);
+      }
+      &:visited {
+        color: var(--link-visited);
+      }
     }
   }
 `;

--- a/system/stories/src/Menu.stories.tsx
+++ b/system/stories/src/Menu.stories.tsx
@@ -13,18 +13,21 @@ export default {
     auxiliaryClassNames: [menuItem.className, menuList.className],
     auxiliarySelectors: [`.${menuItem.className}`, menuList.selectors],
     auxiliaryComponents: [emotion.MenuItem, emotion.MenuList],
-    variants: ['Menu', 'Menu Items']
+    variants: ['Menu', 'Menu Items', 'Selected']
   }
 } as Meta;
 
-function AllMenuItems({ components }: any) {
+function AllMenuItems({ components, isSelected }: any) {
   return (
     <>
       <li>
-        <components.MenuItem>Item</components.MenuItem>
+        <components.MenuItem data-selected={isSelected}>
+          Item
+        </components.MenuItem>
       </li>
       <li>
         <components.MenuItemLink
+          data-selected={isSelected}
           href="#"
           onMouseDown={(e: Event) => {
             e.preventDefault();
@@ -35,6 +38,7 @@ function AllMenuItems({ components }: any) {
       </li>
       <li>
         <components.MenuItem
+          data-selected={isSelected}
           as="button"
           onClick={() => action('button-click')()}
         >
@@ -42,31 +46,31 @@ function AllMenuItems({ components }: any) {
         </components.MenuItem>
       </li>
       <li>
-        <components.MenuItem>
+        <components.MenuItem data-selected={isSelected}>
           <Earth size={20} />
           Item
         </components.MenuItem>
       </li>
       <li>
-        <components.MenuItem data-variant="success">
+        <components.MenuItem data-selected={isSelected} data-variant="success">
           <Earth size={20} />
           Success
         </components.MenuItem>
       </li>
       <li>
-        <components.MenuItem data-variant="info">
+        <components.MenuItem data-selected={isSelected} data-variant="info">
           <Earth size={20} />
           Info
         </components.MenuItem>
       </li>
       <li>
-        <components.MenuItem data-variant="error">
+        <components.MenuItem data-selected={isSelected} data-variant="error">
           <Earth size={20} />
           Error
         </components.MenuItem>
       </li>
       <li>
-        <components.MenuItem data-variant="warning">
+        <components.MenuItem data-selected={isSelected} data-variant="warning">
           <Earth size={20} />
           Warn
         </components.MenuItem>
@@ -84,6 +88,9 @@ const Template: StoryFn = ({ components }) => (
     </components.Menu>
     <components.MenuList style={{ maxHeight: 'none' }}>
       <AllMenuItems components={components} />
+    </components.MenuList>
+    <components.MenuList style={{ maxHeight: 'none' }}>
+      <AllMenuItems components={components} isSelected />
     </components.MenuList>
   </>
 );


### PR DESCRIPTION
If link doesn’t have a href (ie `:link` doesn’t match) we need to make sure it’s disabled display even when hovered. Also added a check to not apply when being used as a "button".
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.202.5898153025.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.202.5898153025.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.202.5898153025.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.202.5898153025.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.202.5898153025.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.202.5898153025.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.202.5898153025.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.202.5898153025.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.202.5898153025.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.202.5898153025.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.202.5898153025.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.202.5898153025.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.202.5898153025.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.202.5898153025.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
