### PR TITLE
fix: move link to Anchor component

### DIFF
--- a/system/.eslintrc.js
+++ b/system/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@tablecheck/eslint-config'],
+  rules: {
+    'jsx-a11y/anchor-has-content': 'off'
+  }
+};

--- a/system/core/src/components/Anchor.ts
+++ b/system/core/src/components/Anchor.ts
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+
+export const element = 'a';
+export const selectors = ['a.link', 'a:not([class])'];
+export const className = 'link';
+
+export interface Props {
+  href?: string | undefined;
+}
+
+export const baseStyles = css`
+  color: var(--internal-link);
+  text-decoration: none;
+  &:not(:any-link) {
+    --internal-link: var(--link-disabled);
+  }
+  &:link {
+    --internal-link: var(--link);
+    &:hover,
+    &:active,
+    &[data-pseudo='hover'] {
+      text-decoration: underline;
+      --internal-link: var(--link-hover);
+    }
+    &:visited,
+    &[data-pseudo='visited'] {
+      --internal-link: var(--link-visited);
+    }
+    &:focus:not(:focus-visible),
+    &:focus-visible,
+    &[data-pseudo='focus'] {
+      outline: none;
+      --internal-link: var(--link-hover);
+      border-radius: 2px;
+      box-shadow: 0 0 0 2px var(--link-hover);
+    }
+  }
+`;

--- a/system/core/src/index.ts
+++ b/system/core/src/index.ts
@@ -3,6 +3,7 @@
  * The exports here are generated from all ts/tsx files at the root level
  */
 export * as alert from './components/Alert';
+export * as anchor from './components/Anchor';
 export * as badge from './components/Badge';
 export * as banner from './components/Banner';
 export * as button from './components/Button';

--- a/system/core/src/utils/resetCss.ts
+++ b/system/core/src/utils/resetCss.ts
@@ -76,17 +76,4 @@ export const resetCss = css`
   button {
     background-color: transparent;
   }
-  a {
-    color: var(--link-disabled);
-    &:link {
-      color: var(--link);
-      &:hover,
-      &:active {
-        color: var(--link-hover);
-      }
-      &:visited {
-        color: var(--link-visited);
-      }
-    }
-  }
 `;

--- a/system/react-css/scripts/generateComponents.mjs
+++ b/system/react-css/scripts/generateComponents.mjs
@@ -67,13 +67,10 @@ class ComponentBuilder {
         `export type ${this.pascalImportKey}Variant = ${this.importKey}.${this.pascalImportKey}Variant;`
       );
     }
-    const elementTypeName = upperFirstChar(this.element);
-    const elementType = `HTML${
-      this.element === 'textarea' ? 'TextArea' : elementTypeName
-    }Element`;
-    const attributesTypePrefix = ['div', 'span'].includes(this.element)
+    const elementType = this.getHtmlElementType();
+    const attributesTypePrefix = ['div', 'span', 'a'].includes(this.element)
       ? ''
-      : elementTypeName;
+      : upperFirstChar(this.element);
     fileContent.push(
       '',
       `export const ${
@@ -101,10 +98,20 @@ class ComponentBuilder {
     return this.className || '';
   }
 
+  getHtmlElementType() {
+    if (this.element === 'a') return 'HTMLAnchorElement';
+    if (this.element === 'textarea') return 'HTMLTextAreaElement';
+    return `HTML${upperFirstChar(this.element)}Element`;
+  }
+
   isValidComponentImport() {
-    return (
-      this.hasValidSelectors() && !structuredFileNames.includes(this.fileName)
-    );
+    if (!this.hasValidSelectors()) {
+      console.warn(
+        `Skipping ${this.importKey} as it does not export 'className' or has a 'defaultProps.type' value set`
+      );
+      return false;
+    }
+    return !structuredFileNames.includes(this.fileName);
   }
 
   hasValidSelectors() {

--- a/system/react-css/src/components/Anchor.tsx
+++ b/system/react-css/src/components/Anchor.tsx
@@ -1,0 +1,16 @@
+/**
+ * DO NOT EDIT: This file is generated, run 'npm update:components' to update this.
+ * The exports here are generated from @tablecheck/tablekit-core
+ * If you need to provide more "structure" to this component move it to the 'structuredComponents' folder
+ */
+import type { anchor } from '@tablecheck/tablekit-core';
+import * as React from 'react';
+
+export type Props = anchor.Props;
+
+export const Anchor = React.forwardRef<
+  HTMLAnchorElement,
+  Props & React.HTMLAttributes<HTMLAnchorElement>
+>((props, ref) => (
+  <a {...props} ref={ref} className={`${props.className || ''} link`} />
+));

--- a/system/react-css/src/index.ts
+++ b/system/react-css/src/index.ts
@@ -4,6 +4,8 @@
  */
 import './globalTypes';
 
+export { Anchor } from './components/Anchor';
+export type { Props as AnchorProps } from './components/Anchor';
 export { Badge } from './components/Badge';
 export type { Props as BadgeProps } from './components/Badge';
 export { Banner } from './components/Banner';

--- a/system/react/scripts/generateComponents.mjs
+++ b/system/react/scripts/generateComponents.mjs
@@ -112,7 +112,12 @@ class ComponentBuilder {
   }
 
   isValidComponentImport() {
-    if (!this.baseStyles) return false;
+    if (!this.baseStyles) {
+      console.warn(
+        `Skipping ${this.importKey} as it does not export 'baseStyles'`
+      );
+      return false;
+    }
     return !structuredFileNames.includes(this.fileName);
   }
 

--- a/system/react/src/components/Anchor.tsx
+++ b/system/react/src/components/Anchor.tsx
@@ -1,0 +1,13 @@
+/**
+ * DO NOT EDIT: This file is generated, run 'npm update:components' to update this.
+ * The exports here are generated from @tablecheck/tablekit-core
+ * If you need to provide more "structure" to this component move it to the 'structuredComponents' folder
+ */
+import styled from '@emotion/styled';
+import { anchor } from '@tablecheck/tablekit-core';
+
+export type Props = anchor.Props;
+
+export const Anchor = styled.a<Props>`
+  ${anchor.baseStyles}
+`;

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -4,6 +4,8 @@
  */
 import './globalTypes';
 
+export { Anchor } from './components/Anchor';
+export type { Props as AnchorProps } from './components/Anchor';
 export { BadgeBase, Badge, VariantBadge } from './components/Badge';
 export type { Props as BadgeProps, BadgeVariant } from './components/Badge';
 export { BannerBase, Banner, VariantBanner } from './components/Banner';

--- a/system/stories/src/Anchor.stories.tsx
+++ b/system/stories/src/Anchor.stories.tsx
@@ -1,0 +1,39 @@
+import { Story, Meta } from '@storybook/react';
+import { anchor } from '@tablecheck/tablekit-core';
+import * as emotion from '@tablecheck/tablekit-react';
+import * as css from '@tablecheck/tablekit-react-css';
+
+const contentVariants = [
+  'Default',
+  'Disabled',
+  'Hover',
+  'Focus',
+  'Visited'
+] as const;
+
+export default {
+  title: 'TableKit/Anchor',
+  component: emotion.Anchor,
+  parameters: {
+    ...anchor,
+    variants: contentVariants
+  }
+} as Meta;
+
+const Template: Story = ({ Anchor }) => (
+  <>
+    {contentVariants.map((variant) => (
+      <Anchor
+        href={variant === 'Disabled' ? undefined : '#'}
+        data-pseudo={variant.toLowerCase()}
+      >
+        Link text here
+      </Anchor>
+    ))}
+  </>
+);
+export const Emotion: Story = Template.bind({});
+Emotion.args = { Anchor: emotion.Anchor };
+
+export const Class: Story = Template.bind({});
+Class.args = { Anchor: css.Anchor };


### PR DESCRIPTION
Globally applying styles to the a tag caused a large amount of regression problems and couldn’t be modified to work easier than we could create a new component for it. Called this component `Anchor` as `a` is an `anchor tag` and `Link` conflicts with React-Router and other routing libraries.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.203.5900611528.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.203.5900611528.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.203.5900611528.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.203.5900611528.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.203.5900611528.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.203.5900611528.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.203.5900611528.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.203.5900611528.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.203.5900611528.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.203.5900611528.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.203.5900611528.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.203.5900611528.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.203.5900611528.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.203.5900611528.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
