### PR TITLE
feat: add component to auto apply anchor styling to children

### DIFF
--- a/system/core/src/components/ChildAnchors.ts
+++ b/system/core/src/components/ChildAnchors.ts
@@ -1,0 +1,15 @@
+import { css } from '@emotion/react';
+
+import { baseStyles as anchorStyles } from './Anchor';
+
+export const element = 'div';
+export const className = 'child-anchors';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Props {}
+
+export const baseStyles = css`
+  & a {
+    ${anchorStyles}
+  }
+`;

--- a/system/core/src/index.ts
+++ b/system/core/src/index.ts
@@ -10,6 +10,7 @@ export * as button from './components/Button';
 export * as buttonGroup from './components/ButtonGroup';
 export * as checkbox from './components/Checkbox';
 export * as checkboxRadioLabel from './components/CheckboxRadioLabel';
+export * as childAnchors from './components/ChildAnchors';
 export * as chip from './components/Chip';
 export * as chipRow from './components/ChipRow';
 export * as iconButton from './components/IconButton';

--- a/system/react-css/src/components/ChildAnchors.tsx
+++ b/system/react-css/src/components/ChildAnchors.tsx
@@ -1,0 +1,20 @@
+/**
+ * DO NOT EDIT: This file is generated, run 'npm update:components' to update this.
+ * The exports here are generated from @tablecheck/tablekit-core
+ * If you need to provide more "structure" to this component move it to the 'structuredComponents' folder
+ */
+import type { childAnchors } from '@tablecheck/tablekit-core';
+import * as React from 'react';
+
+export type Props = childAnchors.Props;
+
+export const ChildAnchors = React.forwardRef<
+  HTMLDivElement,
+  Props & React.HTMLAttributes<HTMLDivElement>
+>((props, ref) => (
+  <div
+    {...props}
+    ref={ref}
+    className={`${props.className || ''} child-anchors`}
+  />
+));

--- a/system/react-css/src/index.ts
+++ b/system/react-css/src/index.ts
@@ -16,6 +16,8 @@ export { ButtonGroup } from './components/ButtonGroup';
 export type { Props as ButtonGroupProps } from './components/ButtonGroup';
 export { Checkbox } from './components/Checkbox';
 export type { Props as CheckboxProps } from './components/Checkbox';
+export { ChildAnchors } from './components/ChildAnchors';
+export type { Props as ChildAnchorsProps } from './components/ChildAnchors';
 export { Chip } from './components/Chip';
 export type { Props as ChipProps } from './components/Chip';
 export { ChipRow } from './components/ChipRow';

--- a/system/react/src/components/ChildAnchors.tsx
+++ b/system/react/src/components/ChildAnchors.tsx
@@ -1,0 +1,13 @@
+/**
+ * DO NOT EDIT: This file is generated, run 'npm update:components' to update this.
+ * The exports here are generated from @tablecheck/tablekit-core
+ * If you need to provide more "structure" to this component move it to the 'structuredComponents' folder
+ */
+import styled from '@emotion/styled';
+import { childAnchors } from '@tablecheck/tablekit-core';
+
+export type Props = childAnchors.Props;
+
+export const ChildAnchors = styled.div<Props>`
+  ${childAnchors.baseStyles}
+`;

--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -18,6 +18,8 @@ export { Checkbox } from './components/Checkbox';
 export type { Props as CheckboxProps } from './components/Checkbox';
 export { CheckboxRadioLabel } from './components/CheckboxRadioLabel';
 export type { Props as CheckboxRadioLabelProps } from './components/CheckboxRadioLabel';
+export { ChildAnchors } from './components/ChildAnchors';
+export type { Props as ChildAnchorsProps } from './components/ChildAnchors';
 export { Chip } from './components/Chip';
 export type { Props as ChipProps } from './components/Chip';
 export { ChipRow } from './components/ChipRow';

--- a/system/stories/src/ChildAnchors.stories.tsx
+++ b/system/stories/src/ChildAnchors.stories.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable eslint-comments/disable-enable-pair, jsx-a11y/anchor-is-valid */
+import { Story, Meta } from '@storybook/react';
+import { childAnchors } from '@tablecheck/tablekit-core';
+import * as emotion from '@tablecheck/tablekit-react';
+import * as css from '@tablecheck/tablekit-react-css';
+
+export default {
+  title: 'TableKit/ChildAnchors',
+  component: emotion.ChildAnchors,
+  parameters: {
+    ...childAnchors
+  }
+} as Meta;
+
+const Template: Story = ({ ChildAnchors }) => (
+  <ChildAnchors>
+    <p>
+      This <a>component</a> <a href="#">will</a>{' '}
+      <a data-pseudo="hover" href="#">
+        automatically
+      </a>{' '}
+      <a data-pseudo="visited" href="#">
+        apply
+      </a>{' '}
+      <a data-pseudo="focus" href="#">
+        the
+      </a>{' '}
+      `Anchor` styling to all `&lt;a&gt;` elements iniside it
+    </p>
+  </ChildAnchors>
+);
+export const Emotion: Story = Template.bind({});
+Emotion.args = { ChildAnchors: emotion.ChildAnchors };
+
+export const Class: Story = Template.bind({});
+Class.args = { ChildAnchors: css.ChildAnchors };


### PR DESCRIPTION
![CleanShot 2023-08-21 at 12 08 15](https://github.com/tablecheck/tablekit/assets/1085899/dd0a794c-9bfe-4756-8555-ab639197fc72)

This would be used in places we have "external" or "user" content as pictured below.
![CleanShot 2023-08-21 at 12 09 22](https://github.com/tablecheck/tablekit/assets/1085899/54762dd0-dbe2-4335-823f-22a5b4caa392)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.1.0-canary.204.5921542409.0
  npm install @tablecheck/tablekit-css@2.1.0-canary.204.5921542409.0
  npm install @tablecheck/tablekit-react-css@2.1.0-canary.204.5921542409.0
  npm install @tablecheck/tablekit-react-datepicker@2.1.0-canary.204.5921542409.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.204.5921542409.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.204.5921542409.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.204.5921542409.0
  # or 
  yarn add @tablecheck/tablekit-core@2.1.0-canary.204.5921542409.0
  yarn add @tablecheck/tablekit-css@2.1.0-canary.204.5921542409.0
  yarn add @tablecheck/tablekit-react-css@2.1.0-canary.204.5921542409.0
  yarn add @tablecheck/tablekit-react-datepicker@2.1.0-canary.204.5921542409.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.204.5921542409.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.204.5921542409.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.204.5921542409.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
