### PR TITLE
fix: prevent text-decoration when using a button as a link

### DIFF
--- a/system/core/src/components/Button.ts
+++ b/system/core/src/components/Button.ts
@@ -103,6 +103,7 @@ export const coreStyles = css`
   padding: 9px 11px;
   white-space: nowrap;
   cursor: pointer;
+  text-decoration: none;
 
   font-weight: 400;
   font-size: 16px;

--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -53,6 +53,7 @@ export const coreStyles = css`
   display: grid;
   padding: 9px;
   cursor: pointer;
+  text-decoration: none;
 
   font-size: 16px;
   line-height: 24px;


### PR DESCRIPTION
No Ticket

Removes the need for this kind of wrapper;

```ts
export const AnchorButton = styled(Button.withComponent('a'))`
  text-decoration: none;
`;
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.205.6142799525.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.205.6142799525.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.205.6142799525.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.205.6142799525.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.205.6142799525.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.205.6142799525.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.205.6142799525.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.205.6142799525.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.205.6142799525.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.205.6142799525.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.205.6142799525.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.205.6142799525.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.205.6142799525.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.205.6142799525.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
