### PR TITLE
feat: implement danger variant for button

### DIFF
--- a/system/core/src/components/Button.ts
+++ b/system/core/src/components/Button.ts
@@ -19,7 +19,14 @@ export interface Props {
   'aria-busy'?: boolean;
 }
 
-const variants = ['primary', 'secondary', 'tertiary', 'ghost', 'bare'] as const;
+const variants = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'ghost',
+  'bare',
+  'danger'
+] as const;
 
 export type ButtonVariant = (typeof variants)[number];
 
@@ -84,6 +91,19 @@ export const variantStyles = {
     --color: var(--text);
     --background-color: transparent;
     --border-color: transparent;
+    &[data-pseudo='hover'],
+    &:hover {
+      --background-color: var(--surface-hover);
+    }
+    &[data-pseudo='active'],
+    &:active {
+      --background-color: var(--surface-active);
+    }
+  `,
+  danger: css`
+    --color: var(--error);
+    --background-color: transparent;
+    --border-color: var(--border-transparent);
     &[data-pseudo='hover'],
     &:hover {
       --background-color: var(--surface-hover);

--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -33,19 +33,7 @@ const variants = [
 export type IconButtonVariant = (typeof variants)[number];
 
 export const variantStyles = {
-  ...buttonVariantStyles,
-  danger: css`
-    --color: var(--error);
-    border: 1px solid var(--border-transparent);
-    &[data-pseudo='hover'],
-    &:hover {
-      --background-color: var(--surface-hover);
-    }
-    &[data-pseudo='active'],
-    &:active {
-      --background-color: var(--surface-active);
-    }
-  `
+  ...buttonVariantStyles
 };
 
 export const coreStyles = css`


### PR DESCRIPTION
Implement #191 

## Changes
1. Implement danger for `Button`
2. Remove danger from `danger` from `IconButton` (since button style is spread in IconButton)

## Screenshots
### Figma Design
![image](https://github.com/tablecheck/tablekit/assets/17337106/4a4647e7-3c0a-4d0d-bfb5-76170cf48101)
### Button
![Screenshot 2023-09-20 at 9 37 25](https://github.com/tablecheck/tablekit/assets/17337106/033c0d5c-b43c-4991-8b5e-fff863c407af)
### IconButton
![Screenshot 2023-09-20 at 9 39 10](https://github.com/tablecheck/tablekit/assets/17337106/e3c6c236-9862-4ae0-9739-cb15411b9b10)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.1.0-canary.206.6243019782.0
  npm install @tablecheck/tablekit-css@2.1.0-canary.206.6243019782.0
  npm install @tablecheck/tablekit-react-css@2.1.0-canary.206.6243019782.0
  npm install @tablecheck/tablekit-react-datepicker@2.1.0-canary.206.6243019782.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.206.6243019782.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.206.6243019782.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.206.6243019782.0
  # or 
  yarn add @tablecheck/tablekit-core@2.1.0-canary.206.6243019782.0
  yarn add @tablecheck/tablekit-css@2.1.0-canary.206.6243019782.0
  yarn add @tablecheck/tablekit-react-css@2.1.0-canary.206.6243019782.0
  yarn add @tablecheck/tablekit-react-datepicker@2.1.0-canary.206.6243019782.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.206.6243019782.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.206.6243019782.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.206.6243019782.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
