### PR TITLE
fix(tablekit-react-select): allow maxMenuHeight to work

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -1100,6 +1100,22 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-26144?component-type=npm&component-name=graphql&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/postcss@7.0.39",
+      "description": "Tool for transforming styles with JS plugins",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/postcss@7.0.39?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-44270",
+          "title": "[CVE-2023-44270] CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')",
+          "description": "An issue was discovered in PostCSS before 8.4.31. The vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being included in a comment.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cve": "CVE-2023-44270",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-44270?component-type=npm&component-name=postcss&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1312,6 +1328,9 @@
     },
     {
       "id": "CVE-2023-26144"
+    },
+    {
+      "id": "CVE-2023-44270"
     }
   ]
 }

--- a/system/react-select/src/index.tsx
+++ b/system/react-select/src/index.tsx
@@ -396,9 +396,10 @@ export function useReactSelectConfig<
         ...styles,
         ...menuStylesObject
       }),
-      menuList: (styles) => ({
+      menuList: (styles, { maxHeight }) => ({
         ...styles,
-        ...menuListStylesObject
+        ...menuListStylesObject,
+        maxHeight: `${maxHeight}px !important`
       }),
       option: (styles, { isFocused, isSelected }) => {
         let stateStyles = {};


### PR DESCRIPTION
Due to how our CSS works when using `react-select`, we have a styling that gets applied with priority over the `max-height` set by `maxMenuHeight`. This PR sticks `!important` on that CSS so it wins out.

A use case with `maxMenuHeight` prop set to `600`:

Before:
<img width="499" alt="CSS rules showing 300px overriding 600px" src="https://github.com/tablecheck/tablekit/assets/107082171/f346bc64-1326-4481-9eaf-60477e4b1804">
After:
<img width="584" alt="CSS rules showing the 600px having priority over 300px" src="https://github.com/tablecheck/tablekit/assets/107082171/b6a5685c-4253-419e-ae3f-686e891d1b25">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.209.6479917599.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.209.6479917599.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.209.6479917599.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.209.6479917599.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.209.6479917599.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.209.6479917599.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.209.6479917599.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.209.6479917599.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.209.6479917599.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.209.6479917599.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.209.6479917599.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.209.6479917599.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.209.6479917599.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.209.6479917599.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
