### PR TITLE
feat: add new Badge sizes

### DIFF
--- a/system/core/src/components/Badge.ts
+++ b/system/core/src/components/Badge.ts
@@ -8,23 +8,36 @@ export const baseStyles = css`
   font: var(--label);
   display: grid;
   grid-auto-flow: column;
-  grid-gap: var(--spacing-l1);
+  gap: var(--spacing-l1);
   align-items: center;
   padding: 6px var(--spacing-l2);
   border-radius: var(--border-radius-small);
   color: var(--neutral-text);
   background-color: var(--neutral-surface);
 
+  &[data-size='x-small'] {
+    padding: 2px 6px;
+    font-size: 12px;
+    line-height: 16px;
+  }
   &[data-size='small'] {
     padding: 4px 6px;
     font-size: 12px;
     line-height: 16px;
   }
+  &[data-size='large'] {
+    padding: 10px 10px;
+    gap: 6px;
+  }
+  &[data-size='x-large'] {
+    padding: 14px 10px;
+    gap: 6px;
+  }
 `;
 
 export interface Props {
   'data-variant'?: BadgeVariant;
-  'data-size'?: 'small';
+  'data-size'?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large';
 }
 
 const variants = [
@@ -34,7 +47,8 @@ const variants = [
   'error',
   'neutral',
   'purple',
-  'orange'
+  'orange',
+  'disabled'
 ] as const;
 
 export type BadgeVariant = (typeof variants)[number];
@@ -42,10 +56,16 @@ export type BadgeVariant = (typeof variants)[number];
 export const variantStyles = variants.reduce(
   (result, key) => ({
     ...result,
-    [key]: css`
-      color: var(--${key}-text);
-      background-color: var(--${key}-surface);
-    `
+    [key]:
+      key === 'disabled'
+        ? css`
+            color: var(--text-disabled);
+            background-color: var(--surface-disabled);
+          `
+        : css`
+            color: var(--${key}-text);
+            background-color: var(--${key}-surface);
+          `
   }),
   {} as Record<BadgeVariant, SerializedStyles>
 );

--- a/system/stories/src/Badge.stories.tsx
+++ b/system/stories/src/Badge.stories.tsx
@@ -14,14 +14,14 @@ export default {
 
 const Template: Story = ({ Badge }) => (
   <>
-    {[undefined, 'small'].map((size) =>
+    {(['x-large', 'large', 'medium', 'small', 'x-small'] as const).map((size) =>
       ['left', 'right', false].map((hasIcon) =>
         variants.map((variant) => (
-          <Badge key={variant} data-variant={variant} data-size={size as any}>
+          <Badge key={variant} data-variant={variant} data-size={size}>
             {hasIcon === 'left' ? (
               <FavoriteFilled size={size ? 16 : 20} />
             ) : null}
-            Text
+            {size}
             {hasIcon === 'right' ? (
               <FavoriteFilled size={size ? 16 : 20} />
             ) : null}


### PR DESCRIPTION
No ticket. Updates from figma

![CleanShot 2023-10-12 at 13 15 30](https://github.com/tablecheck/tablekit/assets/1085899/0049ae0a-d0cf-4434-94b2-dbf99ec5dc1a)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.1.0-canary.210.6491216729.0
  npm install @tablecheck/tablekit-css@2.1.0-canary.210.6491216729.0
  npm install @tablecheck/tablekit-react-css@2.1.0-canary.210.6491216729.0
  npm install @tablecheck/tablekit-react-datepicker@2.1.0-canary.210.6491216729.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.210.6491216729.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.210.6491216729.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.210.6491216729.0
  # or 
  yarn add @tablecheck/tablekit-core@2.1.0-canary.210.6491216729.0
  yarn add @tablecheck/tablekit-css@2.1.0-canary.210.6491216729.0
  yarn add @tablecheck/tablekit-react-css@2.1.0-canary.210.6491216729.0
  yarn add @tablecheck/tablekit-react-datepicker@2.1.0-canary.210.6491216729.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.210.6491216729.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.210.6491216729.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.210.6491216729.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
