### PR TITLE
fix: alert styles

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -1132,6 +1132,22 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-45857?component-type=npm&component-name=axios&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/browserify-sign@4.2.1",
+      "description": "adds node crypto signing for browsers",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/browserify-sign@4.2.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.39",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-46234",
+          "title": "[CVE-2023-46234] CWE-347: Improper Verification of Cryptographic Signature",
+          "description": "browserify-sign is a package to duplicate the functionality of node's crypto public key functions, much of this is based on Fedor Indutny's work on indutny/tls.js. An upper bound check issue in `dsaVerify` function allows an attacker to construct signatures that can be successfully verified by any public key, thus leading to a signature forgery attack. All places in this project that involve DSA verification of user-input signatures will be affected by this vulnerability. This issue has been patched in version 4.2.2.\n",
+          "cvssScore": 6.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+          "cve": "CVE-2023-46234",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-46234?component-type=npm&component-name=browserify-sign&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1350,6 +1366,9 @@
     },
     {
       "id": "CVE-2023-45857"
+    },
+    {
+      "id": "CVE-2023-46234"
     }
   ]
 }

--- a/system/core/src/components/Alert.ts
+++ b/system/core/src/components/Alert.ts
@@ -35,16 +35,16 @@ export const baseStyles = css`
   }
 
   &[data-layout='icon-title-close'] {
-    grid: 'icon title close' 1fr '. description .' 1fr / min-content 1fr min-content;
+    grid: 'icon title close' min-content '. description .' 1fr / min-content 1fr min-content;
   }
   &[data-layout='icon-title'] {
-    grid: 'icon title' 1fr '. description' 1fr / min-content 1fr min-content;
+    grid: 'icon title' min-content '. description' 1fr / min-content 1fr min-content;
   }
   &[data-layout='title-close'] {
-    grid: 'title close' 1fr 'description .' 1fr / 1fr min-content;
+    grid: 'title close' min-content 'description .' 1fr / 1fr min-content;
   }
   &[data-layout='title'] {
-    grid: 'title' 1fr 'description' 1fr / 1fr;
+    grid: 'title' min-content 'description' 1fr / 1fr;
   }
   &[data-layout='icon-close'] {
     grid: 'icon description close' 1fr / min-content 1fr min-content;

--- a/system/stories/src/Alert.stories.tsx
+++ b/system/stories/src/Alert.stories.tsx
@@ -45,7 +45,11 @@ const layouts: {
           <InstanceIcon size={20} />
         </IconWrapper>
         <Title>Title</Title>
-        <Description>More text here</Description>
+        <Description>
+          <p>More text here</p>
+          <p>More text here</p>
+          <p>More text here</p>
+        </Description>
         <CloseButton>
           <CloseIcon />
         </CloseButton>
@@ -57,7 +61,11 @@ const layouts: {
     render: ({ CloseButton, Description, Title }) => (
       <>
         <Title>Title</Title>
-        <Description>More text here</Description>
+        <Description>
+          <p>More text here</p>
+          <p>More text here</p>
+          <p>More text here</p>
+        </Description>
         <CloseButton>
           <CloseIcon />
         </CloseButton>
@@ -72,7 +80,11 @@ const layouts: {
           <InstanceIcon size={20} />
         </IconWrapper>
         <Title>Title</Title>
-        <Description>More text here</Description>
+        <Description>
+          <p>More text here</p>
+          <p>More text here</p>
+          <p>More text here</p>
+        </Description>
       </>
     )
   },
@@ -81,7 +93,11 @@ const layouts: {
     render: ({ Description, Title }) => (
       <>
         <Title>Title</Title>
-        <Description>More text here</Description>
+        <Description>
+          <p>More text here</p>
+          <p>More text here</p>
+          <p>More text here</p>
+        </Description>
       </>
     )
   },
@@ -92,7 +108,11 @@ const layouts: {
         <IconWrapper>
           <InstanceIcon size={16} />
         </IconWrapper>
-        <Description>More text here</Description>
+        <Description>
+          <p>More text here</p>
+          <p>More text here</p>
+          <p>More text here</p>
+        </Description>
         <CloseButton>
           <CloseIcon />
         </CloseButton>
@@ -103,7 +123,11 @@ const layouts: {
     key: 'close',
     render: ({ CloseButton, Description }) => (
       <>
-        <Description>More text here</Description>
+        <Description>
+          <p>More text here</p>
+          <p>More text here</p>
+          <p>More text here</p>
+        </Description>
         <CloseButton>
           <CloseIcon />
         </CloseButton>
@@ -117,7 +141,11 @@ const layouts: {
         <IconWrapper>
           <InstanceIcon size={16} />
         </IconWrapper>
-        <Description>More text here</Description>
+        <Description>
+          <p>More text here</p>
+          <p>More text here</p>
+          <p>More text here</p>
+        </Description>
       </>
     )
   },


### PR DESCRIPTION
No ticket.

The issue example:
<img width="1202" alt="image" src="https://github.com/tablecheck/tablekit/assets/19342294/305da1cf-fbb4-4d1a-86b5-b4dbef21fea3">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.212.6726828953.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.212.6726828953.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.212.6726828953.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.212.6726828953.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.212.6726828953.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.212.6726828953.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.212.6726828953.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.212.6726828953.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.212.6726828953.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.212.6726828953.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.212.6726828953.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.212.6726828953.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.212.6726828953.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.212.6726828953.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
