### PR TITLE
feat(tablekit-core): add bare and disabled-bare, update info styling …

### DIFF
--- a/system/core/src/components/InputAlert.ts
+++ b/system/core/src/components/InputAlert.ts
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 export const element = 'span';
 export const className = 'input-alert';
 
-const variants = ['info', 'error', 'warning'] as const;
+const variants = ['info', 'error', 'warning', 'bare', 'disabled'] as const;
 
 export type InputAlertVariant = (typeof variants)[number];
 
@@ -28,13 +28,14 @@ export const baseStyles = css`
   }
 
   &[data-variant='error'],
-  &[data-variant='warning'] {
+  &[data-variant='warning'],
+  &[data-variant='info'] {
     border-radius: var(--border-radius-small);
     padding: var(--spacing-l2) var(--spacing-l3);
   }
 
-  &[data-variant='info'] > svg:first-child {
-    color: var(--info);
+  &[data-variant='disabled'] {
+    color: var(--text-disabled);
   }
 
   &[data-variant='error'] {
@@ -45,5 +46,10 @@ export const baseStyles = css`
   &[data-variant='warning'] {
     background: var(--warning-surface);
     color: var(--warning-text);
+  }
+
+  &[data-variant='info'] {
+    background: var(--info-surface);
+    color: var(--info-text);
   }
 `;

--- a/system/react-css/src/structuredComponents/InputAlert.tsx
+++ b/system/react-css/src/structuredComponents/InputAlert.tsx
@@ -6,12 +6,16 @@ export interface Props extends inputAlert.Props {
   children: React.ReactNode;
 }
 
-const inputAlertIconMap: Record<inputAlert.Props['data-variant'], JSX.Element> =
-  {
-    info: <Information size={16} />,
-    error: <WarningAltFilled size={16} />,
-    warning: <WarningAlt size={16} />
-  };
+const inputAlertIconMap: Record<
+  inputAlert.Props['data-variant'],
+  JSX.Element | null
+> = {
+  info: <Information size={16} />,
+  error: <WarningAltFilled size={16} />,
+  warning: <WarningAlt size={16} />,
+  bare: null,
+  disabled: null
+};
 
 export const InputAlert = React.forwardRef<
   HTMLSpanElement,

--- a/system/react/src/structuredComponents/InputAlert.tsx
+++ b/system/react/src/structuredComponents/InputAlert.tsx
@@ -11,12 +11,16 @@ export const InputAlertInner = styled(inputAlert.element)<Props>`
   ${inputAlert.baseStyles}
 `;
 
-const inputAlertIconMap: Record<inputAlert.Props['data-variant'], JSX.Element> =
-  {
-    info: <Information size={16} />,
-    error: <WarningAltFilled size={16} />,
-    warning: <WarningAlt size={16} />
-  };
+const inputAlertIconMap: Record<
+  inputAlert.Props['data-variant'],
+  JSX.Element | null
+> = {
+  info: <Information size={16} />,
+  error: <WarningAltFilled size={16} />,
+  warning: <WarningAlt size={16} />,
+  bare: null,
+  disabled: null
+};
 
 export const InputAlert = React.forwardRef<
   HTMLSpanElement,

--- a/system/stories/src/InputAlert.stories.tsx
+++ b/system/stories/src/InputAlert.stories.tsx
@@ -6,7 +6,9 @@ import * as css from '@tablecheck/tablekit-react-css';
 const contentVariants: emotion.InputAlertProps[] = [
   { id: '1', 'data-variant': 'info', children: 'Info' },
   { id: '2', 'data-variant': 'warning', children: 'Warning' },
-  { id: '3', 'data-variant': 'error', children: 'Error' }
+  { id: '3', 'data-variant': 'error', children: 'Error' },
+  { id: '4', 'data-variant': 'bare', children: 'Bare' },
+  { id: '5', 'data-variant': 'disabled', children: 'Disabled' }
 ];
 
 export default {


### PR DESCRIPTION
…in input-alert

Addresses https://github.com/tablecheck/tablekit/issues/192 but also switches `info` to its new styling (it was previously similar to what is now `bare`).

<img width="606" alt="The updated styling for the input-alert, showing info with a blue box, as well as the bare and disabled styles" src="https://github.com/tablecheck/tablekit/assets/107082171/9c234fc5-9ede-4163-b8ba-3f6012673a1a">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.1.0-canary.214.7028846197.0
  npm install @tablecheck/tablekit-css@2.1.0-canary.214.7028846197.0
  npm install @tablecheck/tablekit-react-css@2.1.0-canary.214.7028846197.0
  npm install @tablecheck/tablekit-react-datepicker@2.1.0-canary.214.7028846197.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.214.7028846197.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.214.7028846197.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.214.7028846197.0
  # or 
  yarn add @tablecheck/tablekit-core@2.1.0-canary.214.7028846197.0
  yarn add @tablecheck/tablekit-css@2.1.0-canary.214.7028846197.0
  yarn add @tablecheck/tablekit-react-css@2.1.0-canary.214.7028846197.0
  yarn add @tablecheck/tablekit-react-datepicker@2.1.0-canary.214.7028846197.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.214.7028846197.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.214.7028846197.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.214.7028846197.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
