### PR TITLE
fix: bare and disabled input alert styles

### DIFF
--- a/system/core/src/components/InputAlert.ts
+++ b/system/core/src/components/InputAlert.ts
@@ -37,6 +37,11 @@ export const baseStyles = css`
     padding: var(--spacing-l2) var(--spacing-l3);
   }
 
+  &[data-variant='bare'],
+  &[data-variant='disabled'] {
+    grid-template-columns: 1fr;
+  }
+
   &[data-variant='disabled'] {
     color: var(--text-disabled);
   }


### PR DESCRIPTION
Issue:
<img width="1325" alt="image" src="https://github.com/tablecheck/tablekit/assets/19342294/88fed7bd-f05c-42c9-b008-a1634ef3f491">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.1.0-canary.219.8536829525.0
  npm install @tablecheck/tablekit-css@2.1.0-canary.219.8536829525.0
  npm install @tablecheck/tablekit-react-css@2.1.0-canary.219.8536829525.0
  npm install @tablecheck/tablekit-react-datepicker@2.1.0-canary.219.8536829525.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.219.8536829525.0
  npm install @tablecheck/tablekit-react-select@2.1.0-canary.219.8536829525.0
  npm install @tablecheck/tablekit-react@2.1.0-canary.219.8536829525.0
  # or 
  yarn add @tablecheck/tablekit-core@2.1.0-canary.219.8536829525.0
  yarn add @tablecheck/tablekit-css@2.1.0-canary.219.8536829525.0
  yarn add @tablecheck/tablekit-react-css@2.1.0-canary.219.8536829525.0
  yarn add @tablecheck/tablekit-react-datepicker@2.1.0-canary.219.8536829525.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.1.0-canary.219.8536829525.0
  yarn add @tablecheck/tablekit-react-select@2.1.0-canary.219.8536829525.0
  yarn add @tablecheck/tablekit-react@2.1.0-canary.219.8536829525.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
