### PR TITLE
fix: use disabled text color in input and select

### DIFF
--- a/system/core/src/components/InputWithIcons.ts
+++ b/system/core/src/components/InputWithIcons.ts
@@ -32,6 +32,7 @@ export const baseStyles = css`
 
   & > input,
   & > select {
+    color: currentColor;
     &,
     &[data-pseudo='focus'],
     &:focus {

--- a/system/react-select/src/index.tsx
+++ b/system/react-select/src/index.tsx
@@ -83,7 +83,7 @@ const IconWrapper = styled.div`
 const IndicatorWrapper = styled.div`
   height: 20px;
   svg {
-    color: var(--text);
+    color: currentColor;
   }
 `;
 
@@ -327,7 +327,7 @@ export function useReactSelectConfig<
           backgroundColor: isDisabled
             ? 'var(--surface-disabled)'
             : 'var(--surface)',
-          color: 'var(--text)',
+          color: isDisabled ? 'var(--text-disabled)' : 'var(--text)',
           boxShadow,
           display: 'grid',
           gridTemplateAreas: icon


### PR DESCRIPTION
Apply correct text color for input and select when element is disabled.

Issues: 
<img width="604" alt="image" src="https://github.com/tablecheck/tablekit/assets/19342294/7893f119-464d-4e85-a625-ddd4eabc84bd">
<img width="360" alt="image" src="https://github.com/tablecheck/tablekit/assets/19342294/ee802923-1eeb-4c26-88a6-2f88bcae827f">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.220.8793955100.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.220.8793955100.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.220.8793955100.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.220.8793955100.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.220.8793955100.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.220.8793955100.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.220.8793955100.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.220.8793955100.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.220.8793955100.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.220.8793955100.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.220.8793955100.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.220.8793955100.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.220.8793955100.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.220.8793955100.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
