### PR TITLE
fix: disabled styles for Checkbox and Radio labels

### DIFF
--- a/system/core/src/components/CheckboxRadioLabel.ts
+++ b/system/core/src/components/CheckboxRadioLabel.ts
@@ -3,8 +3,13 @@ import { css } from '@emotion/react';
 export const element = 'label';
 export const selectors = ['label.checkbox', 'label.radio'];
 
+const variants = ['disabled'] as const;
+
+export type CheckboxRadioLabelVariant = (typeof variants)[number];
+
 export interface Props {
   htmlFor?: string;
+  'data-variant'?: CheckboxRadioLabelVariant;
 }
 
 export const baseStyles = css`
@@ -13,4 +18,9 @@ export const baseStyles = css`
   gap: var(--spacing-l2);
   cursor: pointer;
   font: var(--body-1);
+
+  &[data-variant='disabled'], &:has(input:disabled) { {
+    color: var(--text-disabled);
+    cursor: not-allowed;
+  }
 `;


### PR DESCRIPTION
Issue example:
<img width="645" alt="image" src="https://github.com/tablecheck/tablekit/assets/19342294/177df324-a1d6-4eff-8d00-94ed1b9af2fe">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.222.9078713800.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.222.9078713800.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.222.9078713800.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.222.9078713800.0
  npm install @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.222.9078713800.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.222.9078713800.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.222.9078713800.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.222.9078713800.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.222.9078713800.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.222.9078713800.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.222.9078713800.0
  yarn add @tablecheck/tablekit-react-fit-content-textarea@2.0.1-canary.222.9078713800.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.222.9078713800.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.222.9078713800.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
