### PR TITLE
fix: datepicker min date

### DIFF
--- a/system/react-datepicker/src/Root.tsx
+++ b/system/react-datepicker/src/Root.tsx
@@ -1,4 +1,4 @@
-import { addDays, endOfDay } from 'date-fns';
+import { startOfDay, endOfDay } from 'date-fns';
 import { useDayzed, Props as DayzedProps } from 'dayzed';
 import * as React from 'react';
 
@@ -133,7 +133,7 @@ export const Root = React.forwardRef<HTMLDivElement, Props>(
     }
     let safeMinDate: undefined | Date;
     if (minDate) {
-      safeMinDate = endOfDay(addDays(minDate, -1));
+      safeMinDate = startOfDay(minDate);
     }
     const dayzed = useDayzed({
       date,


### PR DESCRIPTION
Do not subtract 1 day for min date prop.

Resolves VCHR-267.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@2.0.1-canary.224.9259474154.0
  npm install @tablecheck/tablekit-css@2.0.1-canary.224.9259474154.0
  npm install @tablecheck/tablekit-react-css@2.0.1-canary.224.9259474154.0
  npm install @tablecheck/tablekit-react-datepicker@2.0.1-canary.224.9259474154.0
  npm install @tablecheck/tablekit-react-select@2.0.1-canary.224.9259474154.0
  npm install @tablecheck/tablekit-react@2.0.1-canary.224.9259474154.0
  # or 
  yarn add @tablecheck/tablekit-core@2.0.1-canary.224.9259474154.0
  yarn add @tablecheck/tablekit-css@2.0.1-canary.224.9259474154.0
  yarn add @tablecheck/tablekit-react-css@2.0.1-canary.224.9259474154.0
  yarn add @tablecheck/tablekit-react-datepicker@2.0.1-canary.224.9259474154.0
  yarn add @tablecheck/tablekit-react-select@2.0.1-canary.224.9259474154.0
  yarn add @tablecheck/tablekit-react@2.0.1-canary.224.9259474154.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
