### PR TITLE
fix: icon button in input-append mode

### DIFF
--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -150,10 +150,8 @@ export const fullStyles = css`
   ${coreStyles}
 
   &[data-mode='input-append'] {
-    height: var(--tk-input-height);
-    --tk-icon-button-padding: 8px !important;
     border-color: transparent !important;
-    margin: 0 -8px;
+    border-radius: calc(var(--border-radius-small) - 1px);
     &:not([data-variant]) {
       ${variantStyles.bare};
     }

--- a/system/core/src/components/InputWithIcons.ts
+++ b/system/core/src/components/InputWithIcons.ts
@@ -75,4 +75,16 @@ export const fullStyles = css`
       );
     }
   }
+  & > [data-mode='input-append'] {
+    height: calc(var(--tk-input-height) - var(--tk-input-border-width) * 2);
+    width: calc(
+      var(--tk-input-icon-size)+ var(--tk-input-icon-gap)+
+        var(--tk-input-icon-end-padding)
+    );
+    --tk-icon-button-padding: 8px !important;
+    margin: 0 -11px 0 -6px;
+  }
+  &[data-size='small'] > [data-mode='input-append'] {
+    margin: 0 -11px 0 -3px;
+  }
 `;

--- a/system/core/src/components/InputWithPrefix.ts
+++ b/system/core/src/components/InputWithPrefix.ts
@@ -81,4 +81,18 @@ export const fullStyles = css`
       );
     }
   }
+
+  & > [data-mode='input-append'] {
+    grid-area: 1/4/1/5;
+    height: calc(var(--tk-input-height) - var(--tk-input-border-width) * 2);
+    width: calc(
+      var(--tk-input-icon-size)+ var(--tk-input-icon-gap)+
+        var(--tk-input-icon-end-padding)
+    );
+    --tk-icon-button-padding: 8px !important;
+    margin: 0 -11px 0 -7px;
+  }
+  &[data-size='small'] > [data-mode='input-append'] {
+    margin: 0 -11px 0 -3px;
+  }
 `;

--- a/system/core/src/components/TextAreaWithIcons.ts
+++ b/system/core/src/components/TextAreaWithIcons.ts
@@ -94,4 +94,16 @@ export const fullStyles = css`
         var(--tk-input-icon-gap)
     );
   }
+  & > [data-mode='input-append'] {
+    height: calc(var(--tk-input-height) - var(--tk-input-border-width) * 2);
+    width: calc(
+      var(--tk-input-icon-size)+ var(--tk-input-icon-gap)+
+        var(--tk-input-icon-end-padding)
+    );
+    --tk-icon-button-padding: 8px !important;
+    margin: 0 -11px 0 -6px;
+  }
+  &[data-size='small'] > [data-mode='input-append'] {
+    margin: 0 -11px 0 -3px;
+  }
 `;

--- a/system/core/src/components/TextAreaWithPrefix.ts
+++ b/system/core/src/components/TextAreaWithPrefix.ts
@@ -97,4 +97,18 @@ export const fullStyles = css`
         var(--tk-input-icon-gap)
     );
   }
+
+  & > [data-mode='input-append'] {
+    grid-area: 1/4/1/5;
+    height: calc(var(--tk-input-height) - var(--tk-input-border-width) * 2);
+    width: calc(
+      var(--tk-input-icon-size)+ var(--tk-input-icon-gap)+
+        var(--tk-input-icon-end-padding)
+    );
+    --tk-icon-button-padding: 8px !important;
+    margin: 0 -11px 0 -8px;
+  }
+  &[data-size='small'] > [data-mode='input-append'] {
+    margin: 0 -11px 0 -3px;
+  }
 `;

--- a/system/stories/src/IconButton.stories.tsx
+++ b/system/stories/src/IconButton.stories.tsx
@@ -22,7 +22,8 @@ const sizes = ['small', 'medium', 'large'] as const;
 const Template: StoryFn<{
   IconButton: typeof css.IconButton | typeof emotion.IconButton;
   Input: typeof css.Input | typeof emotion.Input;
-}> = ({ IconButton, Input }) => (
+  TextArea: typeof css.TextArea | typeof emotion.TextArea;
+}> = ({ IconButton, Input, TextArea }) => (
   <>
     {sizes.map((size) => (
       <React.Fragment key={size}>
@@ -65,28 +66,62 @@ const Template: StoryFn<{
       </React.Fragment>
     ))}
     <h4>Input Append mode</h4>
-    <p style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
-      {sizes.map((size) => (
-        <Input
-          data-size={size}
-          placeholder="Enter a Date"
-          iconAfter={
-            <IconButton data-mode="input-append" data-size={size}>
-              <Calendar size={emotion.getCarbonIconSize(size)} />
-            </IconButton>
-          }
-        />
-      ))}
-    </p>
+    {[{ prefix: undefined }, { prefix: <small>EN</small> }].map(
+      (props, index) => (
+        <p
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}
+        >
+          {sizes.map((size) => (
+            <React.Fragment key={size}>
+              <Input
+                {...props}
+                data-size={size}
+                placeholder="Enter a Date"
+                iconAfter={
+                  <IconButton
+                    data-mode="input-append"
+                    data-size={size}
+                    disabled
+                  >
+                    <Calendar size={emotion.getCarbonIconSize(size)} />
+                  </IconButton>
+                }
+              />
+              <TextArea
+                {...props}
+                data-size={size}
+                placeholder="Enter some text"
+                iconAfter={
+                  <IconButton
+                    data-mode="input-append"
+                    data-size={size}
+                    disabled
+                  >
+                    <Calendar size={emotion.getCarbonIconSize(size)} />
+                  </IconButton>
+                }
+              />
+            </React.Fragment>
+          ))}
+        </p>
+      )
+    )}
   </>
 );
 
 export const Emotion = Template.bind({});
-Emotion.args = { IconButton: emotion.IconButton, Input: emotion.Input };
+Emotion.args = {
+  IconButton: emotion.IconButton,
+  Input: emotion.Input,
+  TextArea: emotion.TextArea
+};
 Emotion.parameters = { useEmotion: true };
 export const EmotionVariants = Template.bind({});
 EmotionVariants.args = {
   Input: emotion.Input,
+  TextArea: emotion.TextArea,
   IconButton: (({ 'data-variant': variant, ...props }: iconButton.Props) => {
     if (!variant) return <emotion.IconButton {...props} />;
     const casedKey = `${variant.substring(0, 1).toUpperCase()}${variant
@@ -99,5 +134,9 @@ EmotionVariants.args = {
 EmotionVariants.parameters = { useEmotion: true };
 
 export const Class = Template.bind({});
-Class.args = { IconButton: css.IconButton, Input: css.Input };
+Class.args = {
+  IconButton: css.IconButton,
+  Input: css.Input,
+  TextArea: css.TextArea
+};
 Class.parameters = { useEmotion: false };


### PR DESCRIPTION
Fixes padding offsets and inconsistencies

## Before

![CleanShot 2024-05-30 at 09 46 23](https://github.com/tablecheck/tablekit/assets/1085899/8485e432-b3ad-44de-af30-f541446e4743)

## After

![CleanShot 2024-05-30 at 12 27 18](https://github.com/tablecheck/tablekit/assets/1085899/9fad5e07-91be-425a-8a7e-bd47245f0229)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@3.0.3-canary.227.9296512980.0
  npm install @tablecheck/tablekit-css@3.0.3-canary.227.9296512980.0
  npm install @tablecheck/tablekit-react@3.0.3-canary.227.9296512980.0
  npm install @tablecheck/tablekit-react-css@3.0.3-canary.227.9296512980.0
  npm install @tablecheck/tablekit-react-datepicker@3.0.3-canary.227.9296512980.0
  npm install @tablecheck/tablekit-react-select@3.0.3-canary.227.9296512980.0
  # or 
  yarn add @tablecheck/tablekit-core@3.0.3-canary.227.9296512980.0
  yarn add @tablecheck/tablekit-css@3.0.3-canary.227.9296512980.0
  yarn add @tablecheck/tablekit-react@3.0.3-canary.227.9296512980.0
  yarn add @tablecheck/tablekit-react-css@3.0.3-canary.227.9296512980.0
  yarn add @tablecheck/tablekit-react-datepicker@3.0.3-canary.227.9296512980.0
  yarn add @tablecheck/tablekit-react-select@3.0.3-canary.227.9296512980.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
