### PR TITLE
fix: disabled prop on Input component is not being respected

### DIFF
--- a/system/core/src/components/InputCore.ts
+++ b/system/core/src/components/InputCore.ts
@@ -4,6 +4,12 @@ export const element = 'input';
 export const selectors = ['input:not([type="checkbox"]):not([type="radio"])'];
 export const className = 'input';
 
+export const heightMap = {
+  small: 36,
+  medium: 40,
+  large: 48
+} as const;
+
 export const fullStyles = css`
   --tk-input-border-width: 1px;
   border: var(--tk-input-border-width) solid var(--border);
@@ -20,17 +26,17 @@ export const fullStyles = css`
   &[data-size='medium'],
   &:not([data-size]) {
     --tk-input-vertical-padding: 8px;
-    --tk-input-height: 40px;
+    --tk-input-height: ${heightMap.medium}px;
   }
 
   &[data-size='small'] {
     --tk-input-vertical-padding: 6px;
-    --tk-input-height: 36px;
+    --tk-input-height: ${heightMap.small}px;
   }
 
   &[data-size='large'] {
     --tk-input-vertical-padding: 12px;
-    --tk-input-height: 48px;
+    --tk-input-height: ${heightMap.large}px;
   }
   --tk-input-horizontal-padding: 12px;
   padding: calc(var(--tk-input-vertical-padding) - var(--tk-input-border-width))

--- a/system/react-css/src/config.tsx
+++ b/system/react-css/src/config.tsx
@@ -4,11 +4,15 @@ import {
   WarningAlt,
   WarningAltFilled
 } from '@carbon/icons-react';
-import { ConfigDefaults as CoreConfigDefaults } from '@tablecheck/tablekit-core';
+import {
+  ConfigDefaults as CoreConfigDefaults,
+  inputCore
+} from '@tablecheck/tablekit-core';
 
 interface ConfigDefaults extends CoreConfigDefaults {
   iconSize: number;
   inputIconSize: number;
+  controlHeight: number;
 }
 
 const moduleVar = {
@@ -21,8 +25,10 @@ export function getConfigDefault<T extends keyof ConfigDefaults>(
   return moduleVar.defaults[key];
 }
 
-export function getCarbonIconSize(size: 'small' | 'medium' | 'large'): number {
-  return size === 'small' ? 16 : 20;
+export function getCarbonIconSize<T extends 'small' | 'medium' | 'large'>(
+  size: T
+): T extends 'small' ? 16 : 20 {
+  return (size === 'small' ? 16 : 20) as never;
 }
 
 /**
@@ -33,6 +39,7 @@ export function getCarbonIconSize(size: 'small' | 'medium' | 'large'): number {
 export function configureDefaults(defaults: CoreConfigDefaults): void {
   moduleVar.defaults = {
     ...defaults,
+    controlHeight: inputCore.heightMap[defaults.controlSize ?? 'medium'],
     inputIconSize: 20,
     iconSize: getCarbonIconSize(defaults.controlSize ?? 'medium')
   };

--- a/system/react-css/src/structuredComponents/Input.tsx
+++ b/system/react-css/src/structuredComponents/Input.tsx
@@ -37,6 +37,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
       onInput,
       style,
       className,
+      disabled: isDisabled,
       iconBefore = null,
       iconAfter = null,
       suffix = null,
@@ -66,7 +67,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
       <Component
         style={style}
         className={className}
-        data-variant={variant}
+        data-variant={isDisabled ? 'disabled' : variant}
         data-stretch={isStretched}
         data-size={size}
         data-with-icon={withIcon}

--- a/system/react/src/config.tsx
+++ b/system/react/src/config.tsx
@@ -4,11 +4,15 @@ import {
   WarningAlt,
   WarningAltFilled
 } from '@carbon/icons-react';
-import { ConfigDefaults as CoreConfigDefaults } from '@tablecheck/tablekit-core';
+import {
+  ConfigDefaults as CoreConfigDefaults,
+  inputCore
+} from '@tablecheck/tablekit-core';
 
 interface ConfigDefaults extends CoreConfigDefaults {
   iconSize: number;
   inputIconSize: number;
+  controlHeight: number;
 }
 
 const moduleVar = {
@@ -21,8 +25,10 @@ export function getConfigDefault<T extends keyof ConfigDefaults>(
   return moduleVar.defaults[key];
 }
 
-export function getCarbonIconSize(size: 'small' | 'medium' | 'large'): number {
-  return size === 'small' ? 16 : 20;
+export function getCarbonIconSize<T extends 'small' | 'medium' | 'large'>(
+  size: T
+): T extends 'small' ? 16 : 20 {
+  return (size === 'small' ? 16 : 20) as never;
 }
 
 /**
@@ -33,6 +39,7 @@ export function getCarbonIconSize(size: 'small' | 'medium' | 'large'): number {
 export function configureDefaults(defaults: CoreConfigDefaults): void {
   moduleVar.defaults = {
     ...defaults,
+    controlHeight: inputCore.heightMap[defaults.controlSize ?? 'medium'],
     inputIconSize: 20,
     iconSize: getCarbonIconSize(defaults.controlSize ?? 'medium')
   };

--- a/system/react/src/structuredComponents/Input.tsx
+++ b/system/react/src/structuredComponents/Input.tsx
@@ -41,6 +41,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
       iconAfter = null,
       suffix = null,
       prefix = null,
+      disabled: isDisabled,
       'data-stretch': isStretched,
       'data-variant': variant,
       'data-pseudo': pseudoDebugger,
@@ -66,7 +67,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>(
       <Component
         style={style}
         className={className}
-        data-variant={variant}
+        data-variant={isDisabled ? 'disabled' : variant}
         data-stretch={isStretched}
         data-size={size}
         data-with-icon={withIcon}

--- a/system/stories/src/Input.stories.tsx
+++ b/system/stories/src/Input.stories.tsx
@@ -15,10 +15,10 @@ const contentVariants = [
   { title: 'Default' },
   { title: 'With Value', defaultValue: 'Some Content' },
   { title: 'Focus', 'data-pseudo': 'focus' },
-  { title: 'Disabled', 'data-variant': 'disabled' as const },
+  { title: 'Disabled', disabled: true },
   {
     title: 'Disabled With Value',
-    'data-variant': 'disabled' as const,
+    disabled: true,
     defaultValue: 'Some Content'
   },
   { title: 'Error', 'data-variant': 'error' as const },


### PR DESCRIPTION
`disabled` is on input props but the “Input Wrapper” type elements need to set `data-variant: ‘disabled’`.

See https://github.com/tablecheck/settings-frontend/pull/878#issuecomment-2140054836
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@3.0.4-canary.229.9311772607.0
  npm install @tablecheck/tablekit-css@3.0.4-canary.229.9311772607.0
  npm install @tablecheck/tablekit-react@3.0.4-canary.229.9311772607.0
  npm install @tablecheck/tablekit-react-css@3.0.4-canary.229.9311772607.0
  npm install @tablecheck/tablekit-react-datepicker@3.0.4-canary.229.9311772607.0
  npm install @tablecheck/tablekit-react-select@3.0.4-canary.229.9311772607.0
  # or 
  yarn add @tablecheck/tablekit-core@3.0.4-canary.229.9311772607.0
  yarn add @tablecheck/tablekit-css@3.0.4-canary.229.9311772607.0
  yarn add @tablecheck/tablekit-react@3.0.4-canary.229.9311772607.0
  yarn add @tablecheck/tablekit-react-css@3.0.4-canary.229.9311772607.0
  yarn add @tablecheck/tablekit-react-datepicker@3.0.4-canary.229.9311772607.0
  yarn add @tablecheck/tablekit-react-select@3.0.4-canary.229.9311772607.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
