### PR TITLE
fix: form banner default icon size

### DIFF
--- a/system/react-css/src/structuredComponents/FormBanner.tsx
+++ b/system/react-css/src/structuredComponents/FormBanner.tsx
@@ -49,8 +49,8 @@ interface ComposedProps extends Props {
 
 function getIcon(variant: Props['data-variant']): JSX.Element {
   if (variant === 'purple' || variant === 'orange')
-    return getSentimentIcon('default');
-  return getSentimentIcon(variant);
+    return getSentimentIcon('default', 16);
+  return getSentimentIcon(variant, 16);
 }
 
 export const FormBanner = React.forwardRef<

--- a/system/react/src/structuredComponents/FormBanner.tsx
+++ b/system/react/src/structuredComponents/FormBanner.tsx
@@ -36,8 +36,8 @@ interface ComposedProps extends Props {
 
 function getIcon(variant: Props['data-variant']): JSX.Element {
   if (variant === 'purple' || variant === 'orange')
-    return getSentimentIcon('default');
-  return getSentimentIcon(variant);
+    return getSentimentIcon('default', 16);
+  return getSentimentIcon(variant, 16);
 }
 
 export const FormBanner = React.forwardRef<


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@3.0.6-canary.231.9348854629.0
  npm install @tablecheck/tablekit-css@3.0.6-canary.231.9348854629.0
  npm install @tablecheck/tablekit-react@3.0.7-canary.231.9348854629.0
  npm install @tablecheck/tablekit-react-css@3.0.7-canary.231.9348854629.0
  npm install @tablecheck/tablekit-react-datepicker@3.0.7-canary.231.9348854629.0
  npm install @tablecheck/tablekit-react-select@3.0.7-canary.231.9348854629.0
  # or 
  yarn add @tablecheck/tablekit-core@3.0.6-canary.231.9348854629.0
  yarn add @tablecheck/tablekit-css@3.0.6-canary.231.9348854629.0
  yarn add @tablecheck/tablekit-react@3.0.7-canary.231.9348854629.0
  yarn add @tablecheck/tablekit-react-css@3.0.7-canary.231.9348854629.0
  yarn add @tablecheck/tablekit-react-datepicker@3.0.7-canary.231.9348854629.0
  yarn add @tablecheck/tablekit-react-select@3.0.7-canary.231.9348854629.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
