### PR TITLE
fix: window is not defined in SSR and throws error

### DIFF
--- a/localNodeModulesSync.mjs
+++ b/localNodeModulesSync.mjs
@@ -20,6 +20,21 @@ for (const target of targets) {
   for (const folder of folders) {
     const root = path.join(systemDir, folder);
     const packageName = fs.readJsonSync(path.join(root, 'package.json')).name;
+    if (packageName === '@tablecheck/tablekit-css') {
+      const dest = path.join(target, 'node_modules', packageName);
+      if (!fs.existsSync(dest)) {
+        continue;
+      }
+      console.log(`Copying ${packageName} to ${target}`);
+      fs.readdirSync(dest, { withFileTypes: true }).forEach((dirent) => {
+        if (dirent.isDirectory()) return;
+        if (!dirent.name.endsWith('.css')) return;
+        fs.copyFileSync(
+          path.join(root, dirent.name),
+          path.join(dest, dirent.name)
+        );
+      });
+    }
     const dest = path.join(target, 'node_modules', packageName, 'lib');
     if (!fs.existsSync(dest)) {
       continue;

--- a/system/react-css/src/structuredComponents/TextArea.tsx
+++ b/system/react-css/src/structuredComponents/TextArea.tsx
@@ -6,7 +6,10 @@ import { TextAreaWithPrefix } from '../components/TextAreaWithPrefix';
 import { TextAreaWithSuffix } from '../components/TextAreaWithSuffix';
 import { getConfigDefault } from '../config';
 
-const hasFieldSizingSupport = window.CSS?.supports?.('field-sizing', 'content');
+const hasFieldSizingSupport =
+  typeof window === 'undefined'
+    ? true
+    : window.CSS?.supports?.('field-sizing', 'content');
 
 export type Props = textAreaCore.DefaultedProps &
   Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'rows' | 'prefix'> & {
@@ -68,7 +71,6 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, Props>(
     }, [iconBefore, iconAfter, suffix, prefix]);
     return (
       <Component
-        data-content={hasFieldSizingSupport ? undefined : props.defaultValue}
         style={style}
         className={className}
         data-variant={variant}

--- a/system/react/src/structuredComponents/TextArea.tsx
+++ b/system/react/src/structuredComponents/TextArea.tsx
@@ -6,7 +6,10 @@ import { TextAreaWithPrefix } from '../components/TextAreaWithPrefix';
 import { TextAreaWithSuffix } from '../components/TextAreaWithSuffix';
 import { getConfigDefault } from '../config';
 
-const hasFieldSizingSupport = window.CSS?.supports?.('field-sizing', 'content');
+const hasFieldSizingSupport =
+  typeof window === 'undefined'
+    ? true
+    : window.CSS?.supports?.('field-sizing', 'content');
 
 export type Props = textAreaCore.DefaultedProps &
   Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'rows' | 'prefix'> & {
@@ -68,7 +71,6 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, Props>(
     }, [iconBefore, iconAfter, suffix, prefix]);
     return (
       <Component
-        data-content={hasFieldSizingSupport ? undefined : props.defaultValue}
         style={style}
         className={className}
         data-variant={variant}


### PR DESCRIPTION
Fixes a crash on SSR
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@3.0.6-canary.232.9375681919.0
  npm install @tablecheck/tablekit-css@3.0.6-canary.232.9375681919.0
  npm install @tablecheck/tablekit-react@3.0.8-canary.232.9375681919.0
  npm install @tablecheck/tablekit-react-css@3.0.8-canary.232.9375681919.0
  npm install @tablecheck/tablekit-react-datepicker@3.0.8-canary.232.9375681919.0
  npm install @tablecheck/tablekit-react-select@3.0.8-canary.232.9375681919.0
  # or 
  yarn add @tablecheck/tablekit-core@3.0.6-canary.232.9375681919.0
  yarn add @tablecheck/tablekit-css@3.0.6-canary.232.9375681919.0
  yarn add @tablecheck/tablekit-react@3.0.8-canary.232.9375681919.0
  yarn add @tablecheck/tablekit-react-css@3.0.8-canary.232.9375681919.0
  yarn add @tablecheck/tablekit-react-datepicker@3.0.8-canary.232.9375681919.0
  yarn add @tablecheck/tablekit-react-select@3.0.8-canary.232.9375681919.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
