### PR TITLE
fix(tablekit-react-select): update various visuals

### DIFF
--- a/system/core/src/components/MenuItem.ts
+++ b/system/core/src/components/MenuItem.ts
@@ -35,7 +35,7 @@ export const fullStylesObject: CSSObject = {
   '&, &:any-link, &:hover': {
     color: 'var(--text)'
   },
-  padding: 'var(--spacing-l3)',
+  padding: 'var(--spacing-l2)',
   borderRadius: 'var(--border-radius-small)',
   display: 'grid',
   gridGap: 'var(--spacing-l2)',

--- a/system/core/src/components/MenuList.ts
+++ b/system/core/src/components/MenuList.ts
@@ -18,6 +18,10 @@ export const fullStylesObject: CSSObject = {
   gridGap: 'var(--spacing-l1)',
   listStyle: 'none',
   alignItems: 'stretch',
+  borderColor: 'var(--border-transparent)',
+  borderRadius: 'var(--border-radius-small)',
+  borderStyle: 'solid',
+  borderWidth: '1px',
   '& > li': {
     display: 'flex',
     justifyContent: 'stretch'

--- a/system/core/src/themeVariables/theme.ts
+++ b/system/core/src/themeVariables/theme.ts
@@ -206,7 +206,7 @@ export const darkColors = css`
   --surface-disabled: rgba(75, 75, 75, 1);
   --surface-hover: rgba(41, 41, 41, 1);
   --surface-hover-transparent: rgba(255, 255, 255, 0.05);
-  --surface-low: rgba(18, 18, 18, 1);
+  --surface-low: rgba(26, 26, 26, 1);
   --surface-low-active: rgba(76, 68, 92, 1);
   --surface-low-hover: rgba(41, 41, 41, 1);
   --surface-low-hover-transparent: rgba(255, 255, 255, 0.05);
@@ -277,7 +277,7 @@ export const darkColorsObject = {
   'surface-disabled': 'rgba(75, 75, 75, 1)',
   'surface-hover': 'rgba(41, 41, 41, 1)',
   'surface-hover-transparent': 'rgba(255, 255, 255, 0.05)',
-  'surface-low': 'rgba(18, 18, 18, 1)',
+  'surface-low': 'rgba(26, 26, 26, 1)',
   'surface-low-active': 'rgba(76, 68, 92, 1)',
   'surface-low-hover': 'rgba(41, 41, 41, 1)',
   'surface-low-hover-transparent': 'rgba(255, 255, 255, 0.05)',


### PR DESCRIPTION
Requested by Tom
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@3.0.6-canary.234.9398313390.0
  npm install @tablecheck/tablekit-css@3.0.6-canary.234.9398313390.0
  npm install @tablecheck/tablekit-react@3.0.10-canary.234.9398313390.0
  npm install @tablecheck/tablekit-react-css@3.0.9-canary.234.9398313390.0
  npm install @tablecheck/tablekit-react-datepicker@3.0.10-canary.234.9398313390.0
  npm install @tablecheck/tablekit-react-select@3.0.10-canary.234.9398313390.0
  # or 
  yarn add @tablecheck/tablekit-core@3.0.6-canary.234.9398313390.0
  yarn add @tablecheck/tablekit-css@3.0.6-canary.234.9398313390.0
  yarn add @tablecheck/tablekit-react@3.0.10-canary.234.9398313390.0
  yarn add @tablecheck/tablekit-react-css@3.0.9-canary.234.9398313390.0
  yarn add @tablecheck/tablekit-react-datepicker@3.0.10-canary.234.9398313390.0
  yarn add @tablecheck/tablekit-react-select@3.0.10-canary.234.9398313390.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
