### PR TITLE
feat: add textarea min-lines

### DIFF
--- a/system/core/src/components/IconButton.ts
+++ b/system/core/src/components/IconButton.ts
@@ -152,6 +152,7 @@ export const fullStyles = css`
   &[data-mode='input-append'] {
     border-color: transparent !important;
     border-radius: calc(var(--border-radius-small) - 1px);
+    align-self: flex-start;
     &:not([data-variant]) {
       ${variantStyles.bare};
     }

--- a/system/core/src/components/InputWithIcons.ts
+++ b/system/core/src/components/InputWithIcons.ts
@@ -82,9 +82,9 @@ export const fullStyles = css`
         var(--tk-input-icon-end-padding)
     );
     --tk-icon-button-padding: 8px !important;
-    margin: 0 -11px 0 -6px;
+    margin: 0 -9px 0 -6px;
   }
   &[data-size='small'] > [data-mode='input-append'] {
-    margin: 0 -11px 0 -3px;
+    margin: 0 -9px 0 -3px;
   }
 `;

--- a/system/core/src/components/TextAreaCore.ts
+++ b/system/core/src/components/TextAreaCore.ts
@@ -13,7 +13,8 @@ export const textareaSizingStyles = css`
   ${inputStyles}
   width: var(--tk-input-width);
   --tk-textarea-height: calc(
-    var(--tk-input-height) - (var(--tk-input-border-width) * 2)
+    2lh + (var(--tk-input-border-width) * 2) +
+      (var(--tk-input-vertical-padding) * 2)
   );
   min-height: var(--tk-textarea-height);
   resize: vertical;
@@ -43,6 +44,10 @@ export const textareaWrapperStyles = css`
     resize: none;
     overflow: hidden;
     align-self: stretch;
+  }
+  & > svg {
+    min-height: var(--tk-input-height);
+    align-self: flex-start;
   }
   @supports (field-sizing: content) {
     &[data-content]:after {

--- a/system/core/src/components/TextAreaWithIcons.ts
+++ b/system/core/src/components/TextAreaWithIcons.ts
@@ -101,9 +101,9 @@ export const fullStyles = css`
         var(--tk-input-icon-end-padding)
     );
     --tk-icon-button-padding: 8px !important;
-    margin: 0 -11px 0 -6px;
+    margin: 0 -9px 0 -6px;
   }
   &[data-size='small'] > [data-mode='input-append'] {
-    margin: 0 -11px 0 -3px;
+    margin: 0 -9px 0 -3px;
   }
 `;


### PR DESCRIPTION
Discovered `lh` units can be about as widely used as the `content` resizing, so just add that in so it "progressively enhances" the textbox when the browser can.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@3.1.0-canary.238.10279101719.0
  npm install @tablecheck/tablekit-css@3.1.0-canary.238.10279101719.0
  npm install @tablecheck/tablekit-react@3.1.0-canary.238.10279101719.0
  npm install @tablecheck/tablekit-react-css@3.1.0-canary.238.10279101719.0
  npm install @tablecheck/tablekit-react-datepicker@3.1.0-canary.238.10279101719.0
  npm install @tablecheck/tablekit-react-select@3.1.0-canary.238.10279101719.0
  # or 
  yarn add @tablecheck/tablekit-core@3.1.0-canary.238.10279101719.0
  yarn add @tablecheck/tablekit-css@3.1.0-canary.238.10279101719.0
  yarn add @tablecheck/tablekit-react@3.1.0-canary.238.10279101719.0
  yarn add @tablecheck/tablekit-react-css@3.1.0-canary.238.10279101719.0
  yarn add @tablecheck/tablekit-react-datepicker@3.1.0-canary.238.10279101719.0
  yarn add @tablecheck/tablekit-react-select@3.1.0-canary.238.10279101719.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
