### PR TITLE
fix: fix button group rtl styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tsconfig.*.json
 .rollup.cache
 /cache
 /.nx
+.tool-versions

--- a/system/core/src/components/ButtonGroup.ts
+++ b/system/core/src/components/ButtonGroup.ts
@@ -73,32 +73,57 @@ export const fullStyles = css`
     }
 
     &:first-child {
-      border-top-left-radius: var(--border-radius-small);
-      border-bottom-left-radius: var(--border-radius-small);
+      [dir='ltr'] & {
+        border-top-left-radius: var(--border-radius-small);
+        border-bottom-left-radius: var(--border-radius-small);
+      }
+      [dir='rtl'] & {
+        border-top-right-radius: var(--border-radius-small);
+        border-bottom-right-radius: var(--border-radius-small);
+      }
       --tk-button-box-shadow: inset 0 0 0 1px var(--tk-button-border-color);
 
       &[data-pseudo='focus'],
       &:focus-visible {
         &:after {
-          border-top-left-radius: 6px;
-          border-bottom-left-radius: 6px;
+          [dir='ltr'] & {
+            border-top-left-radius: 6px;
+            border-bottom-left-radius: 6px;
+          }
+          [dir='rtl'] & {
+            border-top-right-radius: 6px;
+            border-bottom-right-radius: 6px;
+          }
         }
       }
     }
 
     &:not(:first-child) {
-      margin-left: -1px;
+      margin-inline-start: -1px;
+      -webkit-margin-start: -1px;
     }
 
     &:last-child {
-      border-top-right-radius: var(--border-radius-small);
-      border-bottom-right-radius: var(--border-radius-small);
+      [dir='ltr'] & {
+        border-top-right-radius: var(--border-radius-small);
+        border-bottom-right-radius: var(--border-radius-small);
+      }
+      [dir='rtl'] & {
+        border-top-left-radius: var(--border-radius-small);
+        border-bottom-left-radius: var(--border-radius-small);
+      }
 
       &[data-pseudo='focus'],
       &:focus-visible {
         &:after {
-          border-top-right-radius: 6px;
-          border-bottom-right-radius: 6px;
+          [dir='ltr'] & {
+            border-top-right-radius: 6px;
+            border-bottom-right-radius: 6px;
+          }
+          [dir='rtl'] & {
+            border-top-left-radius: 6px;
+            border-bottom-left-radius: 6px;
+          }
         }
       }
     }


### PR DESCRIPTION
Issue:
<img width="644" alt="image" src="https://github.com/user-attachments/assets/c0cd12c9-3dc3-436b-8ab3-6d8a44c8579c">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@3.1.1-canary.239.11270814258.0
  npm install @tablecheck/tablekit-css@3.1.1-canary.239.11270814258.0
  npm install @tablecheck/tablekit-react@3.1.1-canary.239.11270814258.0
  npm install @tablecheck/tablekit-react-css@3.1.1-canary.239.11270814258.0
  npm install @tablecheck/tablekit-react-datepicker@3.1.1-canary.239.11270814258.0
  npm install @tablecheck/tablekit-react-select@3.1.1-canary.239.11270814258.0
  # or 
  yarn add @tablecheck/tablekit-core@3.1.1-canary.239.11270814258.0
  yarn add @tablecheck/tablekit-css@3.1.1-canary.239.11270814258.0
  yarn add @tablecheck/tablekit-react@3.1.1-canary.239.11270814258.0
  yarn add @tablecheck/tablekit-react-css@3.1.1-canary.239.11270814258.0
  yarn add @tablecheck/tablekit-react-datepicker@3.1.1-canary.239.11270814258.0
  yarn add @tablecheck/tablekit-react-select@3.1.1-canary.239.11270814258.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
