### PR TITLE
fix: export "useTablekitTheme" hook

### DIFF
--- a/system/react/src/index.ts
+++ b/system/react/src/index.ts
@@ -154,4 +154,7 @@ export { TableButtonCell } from './structuredComponents/TableButtonCell';
 export type { Props as TableButtonCellProps } from './structuredComponents/TableButtonCell';
 export { TextArea } from './structuredComponents/TextArea';
 export type { Props as TextAreaProps } from './structuredComponents/TextArea';
-export { ThemeProvider } from './structuredComponents/ThemeProvider';
+export {
+  useTablekitTheme,
+  ThemeProvider
+} from './structuredComponents/ThemeProvider';

--- a/system/react/src/structuredComponents/ThemeProvider.tsx
+++ b/system/react/src/structuredComponents/ThemeProvider.tsx
@@ -1,7 +1,8 @@
 import {
   ThemeProvider as EmotionThemeProvider,
   Global,
-  css
+  css,
+  useTheme
 } from '@emotion/react';
 import {
   constants,
@@ -53,6 +54,8 @@ function useIsDark(theme: 'light' | 'dark' | 'system') {
   }, [theme, setIsDark]);
   return isDark;
 }
+
+export const useTablekitTheme = useTheme;
 
 export function ThemeProvider({
   isRtl = false,


### PR DESCRIPTION
This line return empty object in Settings: https://github.com/tablecheck/settings-frontend/blob/main/apps/settings-frontend/src/Common/Reservation/ReservationFlag.tsx#L31