### PR TITLE
fix: typescript definition of withComponent

### DIFF
--- a/system/react-css/src/utils.tsx
+++ b/system/react-css/src/utils.tsx
@@ -47,15 +47,17 @@ export type PropsOf<
 export interface WithComponentType<ComponentProps extends {}> {
   withComponent<C extends React.ComponentClass<React.ComponentProps<C>>>(
     component: C,
-    fixedProps?: Partial<ComponentProps>
+    fixedProps?: Partial<ComponentProps> & Partial<React.ComponentProps<C>>
   ): React.ForwardRefExoticComponent<ComponentProps & PropsOf<C>>;
+
   withComponent<C extends React.ComponentType<React.ComponentProps<C>>>(
     component: C,
-    fixedProps?: Partial<ComponentProps>
+    fixedProps?: Partial<ComponentProps> & Partial<React.ComponentProps<C>>
   ): React.ForwardRefExoticComponent<ComponentProps & PropsOf<C>>;
+
   withComponent<Tag extends keyof ReactJSXIntrinsicElements>(
     tag: Tag,
-    fixedProps?: Partial<ComponentProps>
+    fixedProps?: Partial<ComponentProps> & Partial<React.ComponentProps<Tag>>
   ): React.ForwardRefExoticComponent<
     ComponentProps & ReactJSXIntrinsicElements[Tag]
   >;
@@ -109,9 +111,13 @@ export function buildWithComponent<
   Component.withComponent = function withComponentImplementation<
     P extends { className: string },
     T extends React.ComponentType<P>
-  >(withComponent: T, extraProps: TProps) {
-    const wrappedClassName = [extraProps.className, className].join(' ').trim();
-    const mergedStyles = mergeStyles(style, extraProps.style);
+  >(withComponent: T, extraProps?: TProps) {
+    const wrappedClassName = extraProps?.className
+      ? [extraProps.className, className].join(' ').trim()
+      : className;
+    const mergedStyles = extraProps
+      ? mergeStyles(style, extraProps.style)
+      : style;
     const WrappedComponent = React.forwardRef<T, TProps>((props, ref) =>
       React.createElement(withComponent, {
         ...additionalProps,


### PR DESCRIPTION
Corrects merging of both parent and passed component props, and supports not passing fixedProps at all

![CleanShot 2024-12-05 at 10 37 26](https://github.com/user-attachments/assets/0f55ccfb-f3a1-4513-9b7b-42bddf022a83)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@4.1.2-canary.247.12171589848.0
  npm install @tablecheck/tablekit-css@4.1.2-canary.247.12171589848.0
  npm install @tablecheck/tablekit-react@4.1.2-canary.247.12171589848.0
  npm install @tablecheck/tablekit-react-css@4.1.2-canary.247.12171589848.0
  npm install @tablecheck/tablekit-react-datepicker@4.1.2-canary.247.12171589848.0
  npm install @tablecheck/tablekit-react-select@4.1.2-canary.247.12171589848.0
  # or 
  yarn add @tablecheck/tablekit-core@4.1.2-canary.247.12171589848.0
  yarn add @tablecheck/tablekit-css@4.1.2-canary.247.12171589848.0
  yarn add @tablecheck/tablekit-react@4.1.2-canary.247.12171589848.0
  yarn add @tablecheck/tablekit-react-css@4.1.2-canary.247.12171589848.0
  yarn add @tablecheck/tablekit-react-datepicker@4.1.2-canary.247.12171589848.0
  yarn add @tablecheck/tablekit-react-select@4.1.2-canary.247.12171589848.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
