### PR TITLE
fix: add .active selector to tabs

### DIFF
--- a/system/core/src/components/TabButton.ts
+++ b/system/core/src/components/TabButton.ts
@@ -62,6 +62,7 @@ export const fullStyles = css`
       transform: scale(0.97);
     }
   }
+  &.active,
   &[aria-selected='true'] {
     --tk-tab-button-color: var(--text);
     &:after {


### PR DESCRIPTION
For easy integration with 3rd party libraries that often add `active` class when a link is "active".

Particularly [RRv6](https://reactrouter.com/6.28.1/components/nav-link)+ upgrade where v7 doesn't specify if aria props are used or not.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@4.1.2-canary.248.12782190806.0
  npm install @tablecheck/tablekit-css@4.1.2-canary.248.12782190806.0
  npm install @tablecheck/tablekit-react@4.1.2-canary.248.12782190806.0
  npm install @tablecheck/tablekit-react-css@4.1.3-canary.248.12782190806.0
  npm install @tablecheck/tablekit-react-datepicker@4.1.2-canary.248.12782190806.0
  npm install @tablecheck/tablekit-react-select@4.1.2-canary.248.12782190806.0
  # or 
  yarn add @tablecheck/tablekit-core@4.1.2-canary.248.12782190806.0
  yarn add @tablecheck/tablekit-css@4.1.2-canary.248.12782190806.0
  yarn add @tablecheck/tablekit-react@4.1.2-canary.248.12782190806.0
  yarn add @tablecheck/tablekit-react-css@4.1.3-canary.248.12782190806.0
  yarn add @tablecheck/tablekit-react-datepicker@4.1.2-canary.248.12782190806.0
  yarn add @tablecheck/tablekit-react-select@4.1.2-canary.248.12782190806.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
