### PR TITLE
feat: add more CSS vars for typography

### DIFF
--- a/system/core/src/utils/typography.ts
+++ b/system/core/src/utils/typography.ts
@@ -3,25 +3,61 @@ import { css } from '../utils';
 export const typography = css`
   :root {
     --headline-font-weight: 700;
-    --headline: var(--headline-font-weight) 54px / 64px var(--font-family);
+    --headline-font-size: 54px;
+    --headline-line-height: 64px;
+    --headline: var(--headline-font-weight)
+      var(--tk-headline-font-size, var(--headline-font-size)) /
+      var(--tk-headline-line-height, var(--headline-line-height))
+      var(--font-family);
     --h1-font-weight: 600;
-    --h1: var(--h1-font-weight) 36px / 48px var(--font-family);
+    --h1-font-size: 36px;
+    --h1-line-height: 48px;
+    --h1: var(--h1-font-weight) var(--tk-h1-font-size, var(--h1-font-size)) /
+      var(--tk-h1-line-height, var(--h1-line-height)) var(--font-family);
     --h2-font-weight: 400;
-    --h2: var(--h2-font-weight) 24px / 32px var(--font-family);
+    --h2-font-size: 24px;
+    --h2-line-height: 32px;
+    --h2: var(--h2-font-weight) var(--tk-h2-font-size, var(--h2-font-size)) /
+      var(--tk-h2-line-height, var(--h2-line-height)) var(--font-family);
     --h3-font-weight: 600;
-    --h3: var(--h3-font-weight) 20px / 24px var(--font-family);
+    --h3-font-size: 20px;
+    --h3-line-height: 24px;
+    --h3: var(--h3-font-weight) var(--tk-h3-font-size, var(--h3-font-size)) /
+      var(--tk-h3-line-height, var(--h3-line-height)) var(--font-family);
     --h4-font-weight: 400;
-    --h4: var(--h4-font-weight) 20px / 24px var(--font-family);
+    --h4-font-size: 20px;
+    --h4-line-height: 24px;
+    --h4: var(--h4-font-weight) var(--tk-h4-font-size, var(--h4-font-size)) /
+      var(--tk-h4-line-height, var(--h4-line-height)) var(--font-family);
     --h5-font-weight: 600;
-    --h5: var(--h5-font-weight) 16px / 24px var(--font-family);
+    --h5-font-size: 16px;
+    --h5-line-height: 24px;
+    --h5: var(--h5-font-weight) var(--tk-h5-font-size, var(--h5-font-size)) /
+      var(--tk-h5-line-height, var(--h5-line-height)) var(--font-family);
     --body-1-font-weight: 400;
-    --body-1: var(--body-1-font-weight) 16px / 24px var(--font-family);
+    --body-1-font-size: 16px;
+    --body-1-line-height: 24px;
+    --body-1: var(--body-1-font-weight)
+      var(--tk-body-1-font-size, var(--body-1-font-size)) /
+      var(--tk-body-1-line-height, var(--body-1-line-height)) var(--font-family);
     --body-2-font-weight: 400;
-    --body-2: var(--body-2-font-weight) 14px / 20px var(--font-family);
+    --body-2-font-size: 14px;
+    --body-2-line-height: 20px;
+    --body-2: var(--body-2-font-weight)
+      var(--tk-body-2-font-size, var(--body-2-font-size)) /
+      var(--tk-body-2-line-height, var(--body-2-line-height)) var(--font-family);
     --small-font-weight: 400;
-    --small: var(--small-font-weight) 12px / 18px var(--font-family);
+    --small-font-size: 12px;
+    --small-line-height: 18px;
+    --small: var(--small-font-weight)
+      var(--tk-small-font-size, var(--small-font-size)) /
+      var(--tk-small-line-height, var(--small-line-height)) var(--font-family);
     --label-font-weight: 600;
-    --label: var(--label-font-weight) 14px / 20px var(--font-family);
+    --label-font-size: 14px;
+    --label-line-height: 20px;
+    --label: var(--label-font-weight)
+      var(--tk-label-font-size, var(--label-font-size)) /
+      var(--tk-label-line-height, var(--label-line-height)) var(--font-family);
   }
   header h1 {
     font: var(--headline);


### PR DESCRIPTION
This allows overriding of the font-size and line-height easily for application specific values. eg `—tk-body-1-line-height: 20px`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@4.1.3-canary.249.12800567356.0
  npm install @tablecheck/tablekit-css@4.1.3-canary.249.12800567356.0
  npm install @tablecheck/tablekit-react@4.1.3-canary.249.12800567356.0
  npm install @tablecheck/tablekit-react-css@4.1.4-canary.249.12800567356.0
  npm install @tablecheck/tablekit-react-datepicker@4.1.3-canary.249.12800567356.0
  npm install @tablecheck/tablekit-react-select@4.1.3-canary.249.12800567356.0
  # or 
  yarn add @tablecheck/tablekit-core@4.1.3-canary.249.12800567356.0
  yarn add @tablecheck/tablekit-css@4.1.3-canary.249.12800567356.0
  yarn add @tablecheck/tablekit-react@4.1.3-canary.249.12800567356.0
  yarn add @tablecheck/tablekit-react-css@4.1.4-canary.249.12800567356.0
  yarn add @tablecheck/tablekit-react-datepicker@4.1.3-canary.249.12800567356.0
  yarn add @tablecheck/tablekit-react-select@4.1.3-canary.249.12800567356.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
