### PR TITLE
fix: checkbox indeterminate styling

### DIFF
--- a/system/core/src/components/Checkbox.ts
+++ b/system/core/src/components/Checkbox.ts
@@ -95,7 +95,7 @@ export const fullStyles = css`
       var(--tk-input-check-color),
       var(--tk-input-check-color)
     );
-    background-attachment: center;
+    background-position: top;
     background-size: calc(100% - var(--tk-input-check-thickness) / 2)
       var(--tk-input-check-thickness);
     background-repeat: no-repeat;


### PR DESCRIPTION
![CleanShot 2025-02-10 at 11 23 32](https://github.com/user-attachments/assets/f23cc5bb-bafc-4194-bf1a-7def4febc46f)

Misaligned indeterminate styling - `background-attachment: center` is not valid (not sure when that got deprecated)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@4.1.4-canary.250.13232447551.0
  npm install @tablecheck/tablekit-css@4.1.4-canary.250.13232447551.0
  npm install @tablecheck/tablekit-react@4.1.4-canary.250.13232447551.0
  npm install @tablecheck/tablekit-react-css@4.1.5-canary.250.13232447551.0
  npm install @tablecheck/tablekit-react-datepicker@4.1.4-canary.250.13232447551.0
  npm install @tablecheck/tablekit-react-select@4.1.4-canary.250.13232447551.0
  # or 
  yarn add @tablecheck/tablekit-core@4.1.4-canary.250.13232447551.0
  yarn add @tablecheck/tablekit-css@4.1.4-canary.250.13232447551.0
  yarn add @tablecheck/tablekit-react@4.1.4-canary.250.13232447551.0
  yarn add @tablecheck/tablekit-react-css@4.1.5-canary.250.13232447551.0
  yarn add @tablecheck/tablekit-react-datepicker@4.1.4-canary.250.13232447551.0
  yarn add @tablecheck/tablekit-react-select@4.1.4-canary.250.13232447551.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
