### PR TITLE
fix: textarea overflow

### DIFF
--- a/system/core/src/components/TextAreaCore.ts
+++ b/system/core/src/components/TextAreaCore.ts
@@ -32,6 +32,7 @@ export const textareaWrapperStyles = css`
     display: block;
     content: attr(data-content) ' ';
     white-space: pre-wrap;
+    word-break: break-word;
     visibility: hidden;
     pointer-events: none;
     align-self: stretch;

--- a/system/stories/src/TextArea.stories.tsx
+++ b/system/stories/src/TextArea.stories.tsx
@@ -65,6 +65,25 @@ const getPropRows: (
     {
       prefix: <span>ZH-CN</span>,
       iconAfter
+    },
+    {
+      suffix: <span>.com</span>,
+      defaultValue: 'LongLongLongLongTextWithoutSpaces'
+    },
+    {
+      suffix: <span>@tablecheck.com</span>,
+      iconBefore,
+      'data-stretch': true,
+      defaultValue: 'LongLongLongLongTextWithoutSpaces'
+    },
+    {
+      prefix: <span>EN</span>,
+      defaultValue: 'LongLongLongLongTextWithoutSpaces'
+    },
+    {
+      prefix: <span>ZH-CN</span>,
+      iconAfter,
+      defaultValue: 'LongLongLongLongTextWithoutSpaces'
     }
   ];
 };


### PR DESCRIPTION
Related to [MOPS-2995](https://tablecheck.atlassian.net/browse/MOPS-2995).

[MOPS-2995]: https://tablecheck.atlassian.net/browse/MOPS-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/tablekit-core@4.1.5-canary.251.13673585486.0
  npm install @tablecheck/tablekit-css@4.1.5-canary.251.13673585486.0
  npm install @tablecheck/tablekit-react@4.1.5-canary.251.13673585486.0
  npm install @tablecheck/tablekit-react-css@4.1.6-canary.251.13673585486.0
  npm install @tablecheck/tablekit-react-datepicker@4.1.5-canary.251.13673585486.0
  npm install @tablecheck/tablekit-react-select@4.1.5-canary.251.13673585486.0
  # or 
  yarn add @tablecheck/tablekit-core@4.1.5-canary.251.13673585486.0
  yarn add @tablecheck/tablekit-css@4.1.5-canary.251.13673585486.0
  yarn add @tablecheck/tablekit-react@4.1.5-canary.251.13673585486.0
  yarn add @tablecheck/tablekit-react-css@4.1.6-canary.251.13673585486.0
  yarn add @tablecheck/tablekit-react-datepicker@4.1.5-canary.251.13673585486.0
  yarn add @tablecheck/tablekit-react-select@4.1.5-canary.251.13673585486.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
